### PR TITLE
Generate Fake Data

### DIFF
--- a/EUniversity.Tests/Pagination/QueryablePaginationExtensionsTests.cs
+++ b/EUniversity.Tests/Pagination/QueryablePaginationExtensionsTests.cs
@@ -1,5 +1,5 @@
-﻿using EUniversity.Infrastructure.Pagination;
-using EUniversity.Core.Pagination;
+﻿using EUniversity.Core.Pagination;
+using EUniversity.Infrastructure.Pagination;
 
 namespace EUniversity.Tests.Pagination
 {

--- a/EUniversity.sln
+++ b/EUniversity.sln
@@ -9,9 +9,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EUniversity.Core", "Core\EU
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EUniversity.Infrastructure", "Infrastructure\EUniversity.Infrastructure.csproj", "{5608C68E-E50B-47AD-886F-77B9D52E7C31}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EUniversity.Tests", "EUniversity.Tests\EUniversity.Tests.csproj", "{2FE4BBE3-1646-4C60-9FBC-2A3EA8D8626B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EUniversity.Tests", "EUniversity.Tests\EUniversity.Tests.csproj", "{2FE4BBE3-1646-4C60-9FBC-2A3EA8D8626B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EUniversity.IntegrationTests", "IntegrationTests\EUniversity.IntegrationTests.csproj", "{8600CF5A-4F3B-4D6F-89B2-D311A0CFFD37}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EUniversity.IntegrationTests", "IntegrationTests\EUniversity.IntegrationTests.csproj", "{8600CF5A-4F3B-4D6F-89B2-D311A0CFFD37}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/EUniversity/Extensions/ServiceCollectionExtensions.cs
+++ b/EUniversity/Extensions/ServiceCollectionExtensions.cs
@@ -141,6 +141,7 @@ namespace EUniversity.Extensions
         public static IServiceCollection ConfigureAppServices(this IServiceCollection services)
         {
             return services
+                .AddScoped<TestDataService>()
                 .AddScoped<IAuthService, AuthService>()
                 .AddScoped<IAuthHelper, AuthHelper>()
                 .AddScoped<IUsersService, UsersService>()

--- a/EUniversity/Extensions/WebApplicationExtensions.cs
+++ b/EUniversity/Extensions/WebApplicationExtensions.cs
@@ -2,6 +2,7 @@
 using EUniversity.Core.Models;
 using EUniversity.Core.Policy;
 using EUniversity.Core.Services;
+using EUniversity.Infrastructure.Services;
 using Microsoft.AspNetCore.Identity;
 using System.Reflection;
 
@@ -56,27 +57,24 @@ namespace EUniversity.Extensions
         {
             using var scope = app.Services.CreateScope();
 
-            var userManager =
-                scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
-            var authService =
-                scope.ServiceProvider.GetRequiredService<IAuthService>();
+            var testDataService =
+                scope.ServiceProvider.GetRequiredService<TestDataService>();
 
-            const string studentUserName = "student";
-            const string teacherUserName = "teacher";
-            const string defaultPassword = "Password1!";
-            RegisterDto studentRegisterDto = new("test-student@e-university.com", "Jesse", "Pinkman", "Bruce");
-            RegisterDto teacherRegisterDto = new("test-teacher@e-university.com", "Walter", "White", "Hartwell");
+            testDataService.CreateTestUsers().Wait();
 
-            if (userManager.FindByNameAsync(studentUserName).Result == null)
-            {
-                authService.RegisterAsync(studentRegisterDto,
-                    studentUserName, defaultPassword, Roles.Student).Wait();
-            }
-            if (userManager.FindByNameAsync(teacherUserName).Result == null)
-            {
-                authService.RegisterAsync(teacherRegisterDto,
-                    teacherUserName, defaultPassword, Roles.Teacher).Wait();
-            }
+            return app;
+        }
+
+        public static WebApplication CreateFakeData(this WebApplication app)
+        {
+            using var scope = app.Services.CreateScope();
+
+            var testDataService =
+                scope.ServiceProvider.GetRequiredService<TestDataService>();
+
+            testDataService.CreateRandomUsers().Wait();
+            testDataService.CreateRandomClassrooms().Wait();
+
             return app;
         }
     }

--- a/EUniversity/Program.cs
+++ b/EUniversity/Program.cs
@@ -58,6 +58,11 @@ app.CreateAdministrator();
 if (app.Environment.IsDevelopment())
 {
     app.CreateTestUsers();
+
+    if (args.Contains("--fakedata"))
+    {
+        app.CreateFakeData();
+    }
 }
 
 app.Run();

--- a/EUniversity/Program.cs
+++ b/EUniversity/Program.cs
@@ -61,7 +61,9 @@ if (app.Environment.IsDevelopment())
 
     if (args.Contains("--fakedata"))
     {
+        app.Logger.LogInformation("Generating fake data, please be patient");
         app.CreateFakeData();
+        app.Logger.LogInformation("Fake data have been generated");
     }
 }
 

--- a/Infrastructure/EUniversity.Infrastructure.csproj
+++ b/Infrastructure/EUniversity.Infrastructure.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="AnyAscii" Version="0.3.2" />
+    <PackageReference Include="Bogus" Version="34.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.11">
       <PrivateAssets>all</PrivateAssets>

--- a/Infrastructure/Services/TestDataService.cs
+++ b/Infrastructure/Services/TestDataService.cs
@@ -4,7 +4,6 @@ using EUniversity.Core.Dtos.University;
 using EUniversity.Core.Policy;
 using EUniversity.Core.Services;
 using EUniversity.Infrastructure.Services.University;
-using Microsoft.EntityFrameworkCore.Migrations.Operations;
 
 namespace EUniversity.Infrastructure.Services
 {
@@ -62,7 +61,7 @@ namespace EUniversity.Infrastructure.Services
                 string lastName = faker.Name.LastName();
                 string email = faker.Internet.Email(firstName, lastName);
                 // Add middle name with 15% probabilty:
-                string? middleName = faker.Random.Bool(0.15f) ? 
+                string? middleName = faker.Random.Bool(0.15f) ?
                     faker.Name.FirstName() : null;
 
                 return new(email, firstName, lastName, middleName);
@@ -89,7 +88,7 @@ namespace EUniversity.Infrastructure.Services
             Randomizer.Seed = new(FakeDataGeneratorSeed);
             var classroomsFaker = new Faker<CreateClassromDto>()
                 .CustomInstantiator(f => new CreateClassromDto(
-                    new string(f.Random.Chars('A', 'Z', f.Random.Number(0, 3))) + 
+                    new string(f.Random.Chars('A', 'Z', f.Random.Number(0, 3))) +
                     new string(f.Random.Chars('0', '9', 5))
                     ));
 

--- a/Infrastructure/Services/TestDataService.cs
+++ b/Infrastructure/Services/TestDataService.cs
@@ -1,0 +1,102 @@
+﻿using Bogus;
+using EUniversity.Core.Dtos.Auth;
+using EUniversity.Core.Dtos.University;
+using EUniversity.Core.Policy;
+using EUniversity.Core.Services;
+using EUniversity.Infrastructure.Services.University;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
+
+namespace EUniversity.Infrastructure.Services
+{
+    /// <summary>
+    /// Service that creates test data. 
+    /// <b>Should not be used in the production!</b>
+    /// </summary>
+    public class TestDataService
+    {
+        private readonly IAuthService _authService;
+        private readonly IClassroomsService _classroomsService;
+
+        /// <summary>
+        /// Password that is assigned to all test users(but not for fake users).
+        /// </summary>
+        public const string DefaultPassword = "Password1!";
+        /// <summary>
+        /// Seed for all fake data generations.
+        /// </summary>
+        public const int FakeDataGeneratorSeed = 70222500;
+
+        public TestDataService(IAuthService authService, IClassroomsService classroomsService)
+        {
+            _authService = authService;
+            _classroomsService = classroomsService;
+        }
+
+        /// <summary>
+        /// Creates one test student and one test teacher.
+        /// </summary>
+        public async Task CreateTestUsers()
+        {
+            const string studentUserName = "student";
+            const string teacherUserName = "teacher";
+            RegisterDto studentRegisterDto = new("test-student@e-university.com", "Jesse", "Pinkman", "Bruce");
+            RegisterDto teacherRegisterDto = new("test-teacher@e-university.com", "Walter", "White", "Hartwell");
+
+            await _authService.RegisterAsync(studentRegisterDto,
+                studentUserName, DefaultPassword, Roles.Student);
+
+            await _authService.RegisterAsync(teacherRegisterDto,
+                teacherUserName, DefaultPassword, Roles.Teacher);
+        }
+
+        /// <summary>
+        /// Creates many random teachers and students.
+        /// </summary>
+        /// <param name="teachers">Number of teachers to be created.</param>
+        /// <param name="students">Number of studetns to be created.</param>
+        public async Task CreateRandomUsers(int teachers = 50, int students = 200)
+        {
+            static RegisterDto GenerateUser(Faker faker)
+            {
+                string firstName = faker.Name.FirstName();
+                string lastName = faker.Name.LastName();
+                string email = faker.Internet.Email(firstName, lastName);
+                // Add middle name with 15% probabilty:
+                string? middleName = faker.Random.Bool(0.15f) ? 
+                    faker.Name.FirstName() : null;
+
+                return new(email, firstName, lastName, middleName);
+            }
+
+            Randomizer.Seed = new(FakeDataGeneratorSeed);
+            var usersFaker = new Faker<RegisterDto>()
+                .CustomInstantiator(GenerateUser);
+
+            // Register teachers
+            await _authService.RegisterManyAsync(usersFaker.GenerateLazy(teachers), Roles.Teacher)
+                .ToListAsync();
+            // Register students
+            await _authService.RegisterManyAsync(usersFaker.GenerateLazy(students), Roles.Student)
+                .ToListAsync();
+        }
+
+        /// <summary>
+        /// Creates many random classrooms.
+        /// </summary>
+        /// <param name="classrooms">Number of classrooms to be created.</param>
+        public async Task CreateRandomClassrooms(int classrooms = 70)
+        {
+            Randomizer.Seed = new(FakeDataGeneratorSeed);
+            var classroomsFaker = new Faker<CreateClassromDto>()
+                .CustomInstantiator(f => new CreateClassromDto(
+                    new string(f.Random.Chars('A', 'Z', f.Random.Number(0, 3))) + 
+                    new string(f.Random.Chars('0', '9', 5))
+                    ));
+
+            foreach (var classroom in classroomsFaker.GenerateLazy(classrooms))
+            {
+                await _classroomsService.CreateAsync(classroom);
+            }
+        }
+    }
+}

--- a/IntegrationTests/Services/CrudServiceTest.cs
+++ b/IntegrationTests/Services/CrudServiceTest.cs
@@ -1,0 +1,21 @@
+﻿using EUniversity.Core.Models;
+using EUniversity.Core.Services;
+
+namespace EUniversity.IntegrationTests.Services
+{
+    /// <summary>
+    /// Base tests for CRUD services.
+    /// </summary>
+    /// <typeparam name="TService">The CRUD service type</typeparam>
+    /// <typeparam name="TEntity"></typeparam>
+    /// <typeparam name="TId"></typeparam>
+    /// <typeparam name="TDetailsDto"></typeparam>
+    /// <typeparam name="TCreateDto"></typeparam>
+    /// <typeparam name="TUpdateDto"></typeparam>
+    public class CrudServiceTest<TService, TEntity, TId, TDetailsDto, TCreateDto, TUpdateDto> : ServicesTest
+        where TService : ICrudService<TEntity, TId, TDetailsDto, TCreateDto, TUpdateDto>
+        where TEntity : class, IEntity<TId>
+        where TId : IEquatable<TId>
+    {
+    }
+}

--- a/README.md
+++ b/README.md
@@ -105,6 +105,18 @@ Username: ```admin```
 
 Password: ```Chang3M3InProduct10nPlz!```
 
+## Fake Data Generation
+
+To streamline the testing and development process, our project includes a "Fake Data Generation" feature. You can generate test data by running the following command:
+
+```
+dotnet run --fakedata
+```
+
+This feature utilizes the `Bogus` library to create random data, ensuring that you have a realistic test environment for your application. However, please be aware that this functionality is not intended for use in production environments. Data generation is consistent, so executing this command more than once may create duplicate data. 
+
+**Note:** running the following command may extend the application launch time.
+
 ## Test users
 
 #### Student


### PR DESCRIPTION
This pull request adds the capability to generate fake data for testing purposes. The `Bogus` dependency is used to create random users, teachers, students, and classrooms. 

### Changes
* Added the TestDataService class to the project, which provides methods to generate test data.
* Introduced the Bogus dependency for generating random data.
* Included a seed value for consistent data generation.
* Refactored creation of test users(now it's done inside `TestDataService`)
* Desribed this feature in 'README.md'

### Usage
You can generate test data by running the following command:

```dotnet run --fakedata```

### Added dependencies
* Bogus

### Note
This functionality should only be used for testing and development purposes, as it populates the system with artificial data.