### PR TITLE
Refactor Integration Tests for CRUD

### DIFF
--- a/EUniversity.Tests/Pagination/QueryablePaginationExtensionsTests.cs
+++ b/EUniversity.Tests/Pagination/QueryablePaginationExtensionsTests.cs
@@ -1,5 +1,5 @@
-﻿using EUniversity.Infrastructure.Pagination;
-using EUniversity.Core.Pagination;
+﻿using EUniversity.Core.Pagination;
+using EUniversity.Infrastructure.Pagination;
 
 namespace EUniversity.Tests.Pagination
 {

--- a/IntegrationTests/Controllers/AdminCrudControllersTest.cs
+++ b/IntegrationTests/Controllers/AdminCrudControllersTest.cs
@@ -1,0 +1,68 @@
+﻿using EUniversity.Core.Models;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using System.Net;
+
+namespace EUniversity.IntegrationTests.Controllers
+{
+    /// <summary>
+    /// Class that implements base CRUD controller tests, where PUT, POST and DELETE methods require 
+    /// Administrator role.
+    /// </summary>
+    public abstract class AdminCrudControllersTest<TEntity, TId, TDetailsDto, TCreateDto, TUpdateDto> :
+        CrudControllersTest<TEntity, TId, TDetailsDto, TCreateDto, TUpdateDto>
+        where TEntity : class, IEntity<TId>
+        where TId : IEquatable<TId>
+        where TDetailsDto : class, IEquatable<TDetailsDto>
+        where TCreateDto : class, IEquatable<TCreateDto>
+        where TUpdateDto : class, IEquatable<TUpdateDto>
+    {
+        [Test]
+        public virtual async Task Post_StudentRole_Return403Forbidden()
+        {
+            // Arrange
+            using var client = CreateStudentClient();
+            ServiceMock
+                .CreateAsync(Arg.Any<TCreateDto>())
+                .Throws<InvalidOperationException>();
+
+            // Act
+            var result = await client.PostAsJsonAsync(PostRoute, GetValidCreateDto());
+
+            // Assert
+            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
+        }
+
+        [Test]
+        public virtual async Task Put_StudentRole_Return403Forbidden()
+        {
+            // Arrange
+            using var client = CreateStudentClient();
+            ServiceMock
+                .UpdateAsync(Arg.Any<TId>(), Arg.Any<TUpdateDto>())
+                .Throws<InvalidOperationException>();
+
+            // Act
+            var result = await client.PutAsJsonAsync(PutRoute, GetValidUpdateDto());
+
+            // Assert
+            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
+        }
+
+        [Test]
+        public async Task Delete_StudentRole_Return403Forbidden()
+        {
+            // Arrange
+            using var client = CreateStudentClient();
+            ServiceMock
+                .DeleteAsync(Arg.Any<TId>())
+                .Throws<InvalidOperationException>();
+
+            // Act
+            var result = await client.DeleteAsync(DeleteRoute);
+
+            // Assert
+            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
+        }
+    }
+}

--- a/IntegrationTests/Controllers/CrudControllersTest.cs
+++ b/IntegrationTests/Controllers/CrudControllersTest.cs
@@ -1,0 +1,333 @@
+﻿using EUniversity.Core.Dtos.University;
+using EUniversity.Core.Models;
+using EUniversity.Core.Services;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using NSubstitute.ReturnsExtensions;
+using System.Net;
+
+namespace EUniversity.IntegrationTests.Controllers
+{
+    /// <summary>
+    /// Class that implements base CRUD controller tests.
+    /// </summary>
+    public abstract class CrudControllersTest<TEntity, TId, TDetailsDto, TCreateDto, TUpdateDto>
+        : ControllersTest
+        where TEntity : class, IEntity<TId>
+        where TId : IEquatable<TId>
+        where TDetailsDto : class, IEquatable<TDetailsDto>
+        where TCreateDto : class, IEquatable<TCreateDto>
+        where TUpdateDto : class, IEquatable<TUpdateDto>
+    {
+        /// <summary>
+        /// Mock of the CRUD service. Should be initialized in <see cref="SetUpService"/>
+        /// </summary>
+        protected ICrudService<TEntity, TId, TDetailsDto, TCreateDto, TUpdateDto> ServiceMock
+        { get; set; } = null!;
+
+        /// <summary>
+        /// When implemented, gets test <typeparamref name="TDetailsDto"/>.
+        /// </summary>
+        /// <returns>
+        /// Test <typeparamref name="TDetailsDto"/>.
+        /// </returns>
+        public abstract TDetailsDto GetTestDetailsDto();
+
+        /// <summary>
+        /// When implemented, gets valid <typeparamref name="TCreateDto"/>.
+        /// </summary>
+        /// <returns>
+        /// Valid <typeparamref name="TCreateDto"/>.
+        /// </returns>
+        protected abstract TCreateDto GetValidCreateDto();
+
+        /// <summary>
+        /// When implemented, gets invalid <typeparamref name="TCreateDto"/>.
+        /// </summary>
+        /// <returns>
+        /// Invalid <typeparamref name="TCreateDto"/>.
+        /// </returns>
+        protected abstract TCreateDto GetInvalidCreateDto();
+
+        /// <summary>
+        /// When implemented, gets valid <typeparamref name="TUpdateDto"/>.
+        /// </summary>
+        /// <returns>
+        /// Valid <typeparamref name="TUpdateDto"/>.
+        /// </returns>
+        protected abstract TUpdateDto GetValidUpdateDto();
+
+        /// <summary>
+        /// When implemented, gets invalid <typeparamref name="TUpdateDto"/>.
+        /// </summary>
+        /// <returns>
+        /// Invalid <typeparamref name="TUpdateDto"/>.
+        /// </returns>
+        protected abstract TUpdateDto GetInvalidUpdateDto();
+
+        /// <summary>
+        /// Gets HTTP client used for testing [Authorize] methods. 
+        /// Uses client with 'Administrator' role by default.
+        /// </summary>
+        /// <returns>
+        /// HTTP client for testing [Authorize] methods.
+        /// </returns>
+        protected virtual HttpClient GetTestClient() => CreateAdministratorClient();
+
+        [SetUp]
+        public abstract void SetUpService();
+
+        /// <summary>
+        /// Route of HTTP GET for getting an element by its ID.
+        /// </summary>
+        /// <remarks>
+        /// Authentication is not checked.
+        /// </remarks>
+        public abstract string GetByIdRoute { get; }
+        /// <summary>
+        /// Route of HTTP POST.
+        /// </summary>
+        /// <remarks>
+        /// Authentication is checked.
+        /// </remarks>
+        public abstract string PostRoute { get; }
+        /// <summary>
+        /// Route of HTTP PUT.
+        /// </summary>
+        /// <remarks>
+        /// Authentication is checked.
+        /// </remarks>
+        public abstract string PutRoute { get; }
+        /// <summary>
+        /// Route of HTTP DELETE.
+        /// </summary>
+        /// <remarks>
+        /// Authentication is checked.
+        /// </remarks>
+        public abstract string DeleteRoute { get; }
+
+        /// <summary>
+        /// Default ID to be used for mocking.
+        /// </summary>
+        public abstract TId DefaultId { get; }
+
+        [Test]
+        public virtual async Task GetById_ValidCall_SucceedsAndReturnsValidType()
+        {
+            // Arrange
+            TDetailsDto expectedDto = GetTestDetailsDto();
+            ServiceMock
+                .GetByIdAsync(Arg.Any<TId>())
+                .Returns(expectedDto);
+            using var client = GetTestClient();
+
+            // Act
+            var result = await client.GetAsync(GetByIdRoute);
+
+            // Assert
+            await ServiceMock
+                .Received(1)
+                .GetByIdAsync(DefaultId);
+            result.EnsureSuccessStatusCode();
+            var dto = await result.Content.ReadFromJsonAsync<TDetailsDto>();
+            Assert.That(dto, Is.EqualTo(expectedDto));
+        }
+
+        [Test]
+        public virtual async Task GetById_ElementDoesNotExist_Return404NotFound()
+        {
+            // Arrange
+            ServiceMock
+                .GetByIdAsync(Arg.Any<TId>())
+                .ReturnsNull();
+            using var client = GetTestClient();
+
+            // Act
+            var result = await client.GetAsync(GetByIdRoute);
+
+            // Assert
+            await ServiceMock
+                .Received(1)
+                .GetByIdAsync(DefaultId);
+            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+        }
+
+        [Test]
+        public virtual async Task Post_ValidCall_Succeeds()
+        {
+            // Arrange
+            TCreateDto validCreateDto = GetValidCreateDto();
+            using var client = GetTestClient();
+            ServiceMock
+                .CreateAsync(Arg.Any<TCreateDto>())
+                .Returns(DefaultId);
+
+            // Act
+            var result = await client.PostAsJsonAsync(PostRoute, validCreateDto);
+
+            // Assert
+            result.EnsureSuccessStatusCode();
+            await ServiceMock
+                .Received(1)
+                .CreateAsync(validCreateDto);
+        }
+
+        [Test]
+        public virtual async Task Post_InvalidInput_Returns400BadRequest()
+        {
+            // Arrange
+            using var client = GetTestClient();
+            ServiceMock
+                .CreateAsync(Arg.Any<TCreateDto>())
+                .Throws<InvalidOperationException>();
+
+            // Act
+            var result = await client.PostAsJsonAsync(PostRoute, GetInvalidCreateDto());
+
+            // Assert
+            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+        }
+
+        [Test]
+        public virtual async Task Post_UnauthenticatedUser_Returns401Unauthorized()
+        {
+            // Arrange
+            using var client = CreateUnauthorizedClient();
+            ServiceMock
+                .CreateAsync(Arg.Any<TCreateDto>())
+                .Throws<InvalidOperationException>();
+
+            // Act
+            var result = await client.PostAsJsonAsync(PostRoute, GetValidCreateDto());
+
+            // Assert
+            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+        }
+
+        [Test]
+        public virtual async Task Put_ValidCall_Succeeds()
+        {
+            // Arrange
+            TUpdateDto validUpdateDto = GetValidUpdateDto();
+            using var client = GetTestClient();
+            ServiceMock
+                .UpdateAsync(Arg.Any<TId>(), Arg.Any<TUpdateDto>())
+                .Returns(true);
+
+            // Act
+            var result = await client.PutAsJsonAsync(PutRoute, validUpdateDto);
+
+            // Assert
+            await ServiceMock
+                .Received(1)
+                .UpdateAsync(DefaultId, validUpdateDto);
+            result.EnsureSuccessStatusCode();
+        }
+
+        [Test]
+        public virtual async Task Put_ElementDoesNotExist_Returns404NotFound()
+        {
+            // Arrange
+            TUpdateDto validUpdateDto = GetValidUpdateDto();
+            using var client = GetTestClient();
+            ServiceMock
+                .UpdateAsync(Arg.Any<TId>(), Arg.Any<TUpdateDto>())
+                .Returns(false);
+
+            // Act
+            var result = await client.PutAsJsonAsync(PutRoute, validUpdateDto);
+
+            // Assert
+            await ServiceMock
+                .Received(1)
+                .UpdateAsync(DefaultId, validUpdateDto);
+            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+        }
+
+        [Test]
+        public virtual async Task Put_InvalidInput_Returns400BadRequest()
+        {
+            // Arrange
+            using var client = GetTestClient();
+            ServiceMock
+                .UpdateAsync(Arg.Any<TId>(), Arg.Any<TUpdateDto>())
+                .Throws<InvalidOperationException>();
+
+            // Act
+            var result = await client.PutAsJsonAsync(PutRoute, GetInvalidUpdateDto());
+
+            // Assert
+            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+        }
+
+        [Test]
+        public virtual async Task Put_UnauthenticatedUser_Returns401Unauthorized()
+        {
+            // Arrange
+            using var client = CreateUnauthorizedClient();
+            ServiceMock
+                .UpdateAsync(Arg.Any<TId>(), Arg.Any<TUpdateDto>())
+                .Throws<InvalidOperationException>();
+
+            // Act
+            var result = await client.PutAsJsonAsync(PutRoute, GetValidUpdateDto());
+
+            // Assert
+            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+        }
+
+        [Test]
+        public virtual async Task Delete_ValidCall_Succeeds()
+        {
+            // Arrange
+            using var client = GetTestClient();
+            ServiceMock
+                .DeleteAsync(Arg.Any<TId>())
+                .Returns(true);
+
+            // Act
+            var result = await client.DeleteAsync(DeleteRoute);
+
+            // Assert
+            await ServiceMock
+                .Received(1)
+                .DeleteAsync(DefaultId);
+            result.EnsureSuccessStatusCode();
+        }
+
+        [Test]
+        public virtual async Task Delete_ElementDoesNotExist_Return404NotFound()
+        {
+            // Arrange
+            using var client = GetTestClient();
+            ServiceMock
+                .DeleteAsync(Arg.Any<TId>())
+                .Returns(false);
+
+            // Act
+            var result = await client.DeleteAsync(DeleteRoute);
+
+            // Assert
+            await ServiceMock
+                .Received(1)
+                .DeleteAsync(DefaultId);
+            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+        }
+
+        [Test]
+        public async Task Delete_UnauthenticatedUser_Returns401Unauthorized()
+        {
+            // Arrange
+            using var client = CreateUnauthorizedClient();
+            ServiceMock
+                .DeleteAsync(Arg.Any<TId>())
+                .Throws<InvalidOperationException>();
+
+            // Act
+            var result = await client.DeleteAsync(DeleteRoute);
+
+            // Assert
+            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+        }
+    }
+}

--- a/IntegrationTests/Controllers/CrudControllersTest.cs
+++ b/IntegrationTests/Controllers/CrudControllersTest.cs
@@ -1,5 +1,4 @@
-﻿using EUniversity.Core.Dtos.University;
-using EUniversity.Core.Models;
+﻿using EUniversity.Core.Models;
 using EUniversity.Core.Services;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;

--- a/IntegrationTests/Controllers/University/ClassroomsControllerTests.cs
+++ b/IntegrationTests/Controllers/University/ClassroomsControllerTests.cs
@@ -1,301 +1,49 @@
 ﻿using EUniversity.Core.Dtos.University;
-using Microsoft.AspNetCore.Http;
-using NSubstitute;
-using NSubstitute.ExceptionExtensions;
-using NSubstitute.ReturnsExtensions;
-using System.Net;
+using EUniversity.Core.Models.University;
 
 namespace EUniversity.IntegrationTests.Controllers.University
 {
-    public class ClassroomsControllerTests : ControllersTest
+    public class ClassroomsControllerTests :
+        AdminCrudControllersTest<Classroom, int, ViewClassroomDto, CreateClassromDto, CreateClassromDto>
     {
-        public static readonly CreateClassromDto InvalidCreateClassroomDto = new(string.Empty);
-        public static readonly CreateClassromDto ValidCreateClassroomDto = new("300");
+        public override string GetByIdRoute => $"api/classrooms/{DefaultId}";
 
-        public const int DefaultIntId = 1;
-        public static readonly string GetByIdRoute = $"/api/classrooms/{DefaultIntId}";
-        public const string PostRoute = "/api/classrooms";
-        public static readonly string PutRoute = $"/api/classrooms/{DefaultIntId}";
-        public static readonly string DeleteRoute = $"/api/classrooms/{DefaultIntId}";
+        public override string PostRoute => $"api/classrooms/";
 
-        [Test]
-        public async Task GetById_ValidCall_SucceedsAndReturnsValidType()
+        public override string PutRoute => $"api/classrooms/{DefaultId}";
+
+        public override string DeleteRoute => $"api/classrooms/{DefaultId}";
+
+        public override int DefaultId => 1;
+
+        public override void SetUpService()
         {
-            // Arrange
-            ViewClassroomDto expectedDto = new("101");
-            WebApplicationFactory.ClassroomsServiceMock
-                .GetByIdAsync(Arg.Any<int>())
-                .Returns(expectedDto);
-            using var client = CreateAdministratorClient();
-
-            // Act
-            var result = await client.GetAsync(GetByIdRoute);
-
-            // Assert
-            await WebApplicationFactory.ClassroomsServiceMock
-                .Received(1)
-                .GetByIdAsync(DefaultIntId);
-            result.EnsureSuccessStatusCode();
-            var dto = await result.Content.ReadFromJsonAsync<ViewClassroomDto>();
-            Assert.That(dto, Is.EqualTo(expectedDto));
+            ServiceMock = WebApplicationFactory.ClassroomsServiceMock;
         }
 
-        [Test]
-        public async Task GetById_ElementDoesNotExist_Return404NotFound()
+        public override ViewClassroomDto GetTestDetailsDto()
         {
-            // Arrange
-            WebApplicationFactory.ClassroomsServiceMock
-                .GetByIdAsync(Arg.Any<int>())
-                .ReturnsNull();
-            using var client = CreateAdministratorClient();
-
-            // Act
-            var result = await client.GetAsync(GetByIdRoute);
-
-            // Assert
-            await WebApplicationFactory.ClassroomsServiceMock
-                .Received(1)
-                .GetByIdAsync(DefaultIntId);
-            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+            return new("Test classroom");
         }
 
-        [Test]
-        public async Task GetById_UnauthenticatedUser_Returns401Unauthorized()
+        protected override CreateClassromDto GetInvalidCreateDto()
         {
-            // Arrange
-            using var client = CreateUnauthorizedClient();
-            WebApplicationFactory.ClassroomsServiceMock
-                .GetByIdAsync(Arg.Any<int>())
-                .Throws<InvalidOperationException>();
-
-            // Act
-            var result = await client.GetAsync(GetByIdRoute);
-
-            // Assert
-            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+            return new(string.Empty);
         }
 
-        [Test]
-        public async Task Post_ValidCall_Succeeds()
+        protected override CreateClassromDto GetInvalidUpdateDto()
         {
-            // Arrange
-            using var client = CreateAdministratorClient();
-            WebApplicationFactory.ClassroomsServiceMock
-                .CreateAsync(Arg.Any<CreateClassromDto>())
-                .Returns(2);
-
-            // Act
-            var result = await client.PostAsJsonAsync(PostRoute, ValidCreateClassroomDto);
-
-            // Assert
-            result.EnsureSuccessStatusCode();
-            await WebApplicationFactory.ClassroomsServiceMock
-                .Received(1)
-                .CreateAsync(ValidCreateClassroomDto);
+            return new(string.Empty);
         }
 
-        [Test]
-        public async Task Post_InvalidInput_Returns400BadRequest()
+        protected override CreateClassromDto GetValidCreateDto()
         {
-            // Arrange
-            using var client = CreateAdministratorClient();
-            WebApplicationFactory.ClassroomsServiceMock
-                .CreateAsync(Arg.Any<CreateClassromDto>())
-                .Throws<InvalidOperationException>();
-
-            // Act
-            var result = await client.PostAsJsonAsync(PostRoute, InvalidCreateClassroomDto);
-
-            // Assert
-            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+            return new("#100");
         }
 
-        [Test]
-        public async Task Post_UnauthenticatedUser_Returns401Unauthorized()
+        protected override CreateClassromDto GetValidUpdateDto()
         {
-            // Arrange
-            using var client = CreateUnauthorizedClient();
-            WebApplicationFactory.ClassroomsServiceMock
-                .CreateAsync(Arg.Any<CreateClassromDto>())
-                .Throws<InvalidOperationException>();
-
-            // Act
-            var result = await client.PostAsJsonAsync(PostRoute, ValidCreateClassroomDto);
-
-            // Assert
-            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
-        }
-
-        [Test]
-        public async Task Post_StudentRole_Return403Forbidden()
-        {
-            // Arrange
-            using var client = CreateStudentClient();
-            WebApplicationFactory.ClassroomsServiceMock
-                .CreateAsync(Arg.Any<CreateClassromDto>())
-                .Throws<InvalidOperationException>();
-
-            // Act
-            var result = await client.PostAsJsonAsync(PostRoute, ValidCreateClassroomDto);
-
-            // Assert
-            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
-        }
-
-        [Test]
-        public async Task Put_ValidCall_Succeeds()
-        {
-            // Arrange
-            using var client = CreateAdministratorClient();
-            WebApplicationFactory.ClassroomsServiceMock
-                .UpdateAsync(Arg.Any<int>(), Arg.Any<CreateClassromDto>())
-                .Returns(true);
-
-            // Act
-            var result = await client.PutAsJsonAsync(PutRoute, ValidCreateClassroomDto);
-
-            // Assert
-            await WebApplicationFactory.ClassroomsServiceMock
-                .Received(1)
-                .UpdateAsync(DefaultIntId, ValidCreateClassroomDto);
-            result.EnsureSuccessStatusCode();
-        }
-
-        [Test]
-        public async Task Put_ElementDoesNotExist_Returns404NotFound()
-        {
-            // Arrange
-            using var client = CreateAdministratorClient();
-            WebApplicationFactory.ClassroomsServiceMock
-                .UpdateAsync(Arg.Any<int>(), Arg.Any<CreateClassromDto>())
-                .Returns(false);
-
-            // Act
-            var result = await client.PutAsJsonAsync(PutRoute, ValidCreateClassroomDto);
-
-            // Assert
-            await WebApplicationFactory.ClassroomsServiceMock
-                .Received(1)
-                .UpdateAsync(DefaultIntId, ValidCreateClassroomDto);
-            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
-        }
-
-        [Test]
-        public async Task Put_InvalidInput_Returns400BadRequest()
-        {
-            // Arrange
-            using var client = CreateAdministratorClient();
-            WebApplicationFactory.ClassroomsServiceMock
-                .UpdateAsync(Arg.Any<int>(), Arg.Any<CreateClassromDto>())
-                .Throws<InvalidOperationException>();
-
-            // Act
-            var result = await client.PutAsJsonAsync(PutRoute, InvalidCreateClassroomDto);
-
-            // Assert
-            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
-        }
-
-        [Test]
-        public async Task Put_UnauthenticatedUser_Returns401Unauthorized()
-        {
-            // Arrange
-            using var client = CreateUnauthorizedClient();
-            WebApplicationFactory.ClassroomsServiceMock
-                .UpdateAsync(Arg.Any<int>(), Arg.Any<CreateClassromDto>())
-                .Throws<InvalidOperationException>();
-
-            // Act
-            var result = await client.PutAsJsonAsync(PutRoute, ValidCreateClassroomDto);
-
-            // Assert
-            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
-        }
-
-        [Test]
-        public async Task Put_StudentRole_Return403Forbidden()
-        {
-            // Arrange
-            using var client = CreateStudentClient();
-            WebApplicationFactory.ClassroomsServiceMock
-                .UpdateAsync(Arg.Any<int>(), Arg.Any<CreateClassromDto>())
-                .Throws<InvalidOperationException>();
-
-            // Act
-            var result = await client.PutAsJsonAsync(PutRoute, ValidCreateClassroomDto);
-
-            // Assert
-            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
-        }
-
-        [Test]
-        public async Task Delete_ValidCall_Succeeds()
-        {
-            // Arrange
-            using var client = CreateAdministratorClient();
-            WebApplicationFactory.ClassroomsServiceMock
-                .DeleteAsync(Arg.Any<int>())
-                .Returns(true);
-
-            // Act
-            var result = await client.DeleteAsync(DeleteRoute);
-
-            // Assert
-            await WebApplicationFactory.ClassroomsServiceMock
-                .Received(1)
-                .DeleteAsync(DefaultIntId);
-            result.EnsureSuccessStatusCode();
-        }
-
-        [Test]
-        public async Task Delete_ElementDoesNotExist_Return404NotFound()
-        {
-            // Arrange
-            using var client = CreateAdministratorClient();
-            WebApplicationFactory.ClassroomsServiceMock
-                .DeleteAsync(Arg.Any<int>())
-                .Returns(false);
-
-            // Act
-            var result = await client.DeleteAsync(DeleteRoute);
-
-            // Assert
-            await WebApplicationFactory.ClassroomsServiceMock
-                .Received(1)
-                .DeleteAsync(DefaultIntId);
-            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
-        }
-
-        [Test]
-        public async Task Delete_UnauthenticatedUser_Returns401Unauthorized()
-        {
-            // Arrange
-            using var client = CreateUnauthorizedClient();
-            WebApplicationFactory.ClassroomsServiceMock
-                .DeleteAsync(Arg.Any<int>())
-                .Throws<InvalidOperationException>();
-
-            // Act
-            var result = await client.DeleteAsync(DeleteRoute);
-
-            // Assert
-            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
-        }
-
-        [Test]
-        public async Task Delete_StudentRole_Return403Forbidden()
-        {
-            // Arrange
-            using var client = CreateStudentClient();
-            WebApplicationFactory.ClassroomsServiceMock
-                .DeleteAsync(Arg.Any<int>())
-                .Throws<InvalidOperationException>();
-
-            // Act
-            var result = await client.DeleteAsync(DeleteRoute);
-
-            // Assert
-            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
+            return new("#200");
         }
     }
 }

--- a/IntegrationTests/Services/CrudServicesTest.cs
+++ b/IntegrationTests/Services/CrudServicesTest.cs
@@ -1,0 +1,188 @@
+﻿using EUniversity.Core.Models;
+using EUniversity.Core.Models.University;
+using EUniversity.Core.Services;
+using Mapster;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EUniversity.IntegrationTests.Services
+{
+    /// <summary>
+    /// Class that implements base CRUD service tests.
+    /// </summary>
+    public abstract class CrudServicesTest<TService, TEntity, TId, TDetailsDto, TCreateDto, TUpdateDto>
+         : ServicesTest
+        where TService : ICrudService<TEntity, TId, TDetailsDto, TCreateDto, TUpdateDto>
+        where TEntity : class, IEntity<TId>
+        where TId : IEquatable<TId>
+    {
+        protected TService Service { get; private set; }
+
+        [SetUp]
+        public virtual void SetUpService()
+        {
+            Service = ServiceScope.ServiceProvider.GetService<TService>()!;
+        }
+
+        /// <summary>
+        /// Check whether an entity with <paramref name="id"/> exists.
+        /// </summary>
+        /// <param name="id">ID of the entity.</param>
+        /// <returns>
+        /// <see langword="true" /> if entity exists;
+        /// <see langword="false" /> otherwise.
+        /// </returns>
+        protected async Task<bool> EntityExistsAsync(TId id)
+        {
+            return await DbContext.Set<Classroom>().AnyAsync(x => x.Id.Equals(id));
+        }
+
+        /// <summary>
+        /// When implemented, gets a test entity that can be added to the DB.
+        /// </summary>
+        /// <returns>
+        /// Entity that can be added to the DB.
+        /// </returns>
+        protected abstract TEntity GetTestEntity();
+
+        /// <summary>
+        /// When implemented, gets valid creation DTO.
+        /// </summary>
+        /// <returns>
+        /// Valid DTO used for creation.
+        /// </returns>
+        protected abstract TCreateDto GetValidCreateDto();
+
+        /// <summary>
+        /// When implemented, gets valid update/edit DTO.
+        /// </summary>
+        /// <returns>
+        /// Valid DTO used for update/edit.
+        /// </returns>
+        protected abstract TUpdateDto GetValidUpdateDto();
+
+        /// <summary>
+        /// Gets the identifier that represents a non-existent entity.
+        /// </summary>
+        /// <returns>
+        /// The identifier for a non-existent entity.
+        /// </returns>
+        protected abstract TId GetNonExistentId();
+
+        /// <summary>
+        /// Creates test entity and adds it to the DB.
+        /// </summary>
+        /// <returns>
+        /// <see cref="TEntity" /> that was created.
+        /// </returns>
+        protected virtual async Task<TEntity> CreateTestEntityAsync()
+        {
+            var entity = GetTestEntity();
+            DbContext.Add(entity);
+            await DbContext.SaveChangesAsync();
+
+            return entity;
+        }
+
+        /// <summary>
+        /// When implemented, asserts that entity was actually updated.
+        /// </summary>
+        /// <param name="actualEntity">Entity, that should be updated.</param>
+        /// <param name="updateDto">Update DTO, that was used to update entity.</param>
+        protected abstract void AssertThatWasUpdated(TEntity actualEntity, TUpdateDto updateDto);
+
+        [Test]
+        public virtual async Task GetById_ElementExists_ReturnsValidElement()
+        {
+            // Arrange
+            var classroom = await CreateTestEntityAsync();
+            var expectedResult = classroom.Adapt<TDetailsDto>();
+
+            // Act
+            var result = await Service.GetByIdAsync(classroom.Id);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(expectedResult));
+        }
+
+        [Test]
+        public virtual async Task GetById_ElementDoesNotExist_ReturnsNull()
+        {
+            // Act
+            var result = await Service.GetByIdAsync(GetNonExistentId());
+
+            // Assert
+            Assert.That(result, Is.Null);
+        }
+
+        [Test]
+        public virtual async Task Create_ValidInput_CreatesElement()
+        {
+            // Arrange
+            TCreateDto dto = GetValidCreateDto();
+
+            // Act
+            TId id = await Service.CreateAsync(dto);
+
+            // Assert(check if element is actually created)
+            Assert.That(await EntityExistsAsync(id));
+        }
+
+        [Test]
+        public virtual async Task Update_ElementExists_Succeeds()
+        {
+            // Arrange
+            var entity = await CreateTestEntityAsync();
+            TUpdateDto dto = GetValidUpdateDto();
+            var expectedClassroom = dto.Adapt<Classroom>();
+
+            // Act
+            bool result = await Service.UpdateAsync(entity.Id, dto);
+
+            // Assert
+            Assert.That(result);
+            var actualEntity = await DbContext.Set<TEntity>()
+                .FirstOrDefaultAsync(c => c.Id.Equals(entity.Id));
+            // Check if element was updated
+            Assert.That(actualEntity, Is.Not.Null);
+            AssertThatWasUpdated(actualEntity, dto);
+        }
+
+        [Test]
+        public virtual async Task Update_ElementDoesNotExist_ReturnFalse()
+        {
+            // Act
+            bool result = await Service.UpdateAsync(GetNonExistentId(), GetValidUpdateDto());
+
+            // Arrange
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public virtual async Task Delete_ElementExists_Succeeds()
+        {
+            // Arrange
+            var classroom = await CreateTestEntityAsync();
+
+            // Act
+            bool result = await Service.DeleteAsync(classroom.Id);
+
+            // Assert
+            Assert.Multiple(async () =>
+            {
+                Assert.That(result);
+                Assert.That(await EntityExistsAsync(classroom.Id), Is.False);
+            });
+        }
+
+        [Test]
+        public virtual async Task Delete_ElementDoesNotExist_ReturnsFalse()
+        {
+            // Act
+            bool result = await Service.DeleteAsync(GetNonExistentId());
+
+            // Assert
+            Assert.That(result, Is.False);
+        }
+    }
+}

--- a/IntegrationTests/Services/University/ClassroomsServiceTests.cs
+++ b/IntegrationTests/Services/University/ClassroomsServiceTests.cs
@@ -1,130 +1,40 @@
 ﻿using EUniversity.Core.Dtos.University;
 using EUniversity.Core.Models.University;
 using EUniversity.Infrastructure.Services.University;
-using Mapster;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace EUniversity.IntegrationTests.Services.University
 {
-    public class ClassroomsServiceTests : ServicesTest
+    public class ClassroomsServiceTests : CrudServicesTest
+        <IClassroomsService, Classroom, int, ViewClassroomDto, CreateClassromDto, CreateClassromDto>
     {
-        private IClassroomsService _classroomsService;
-        public static readonly CreateClassromDto
-            DefaultCreateClassroomDto = new("new classroom");
-
-        private async Task<Classroom> CreateDefaultClassroomAsync()
+        /// <inheritdoc />
+        protected override void AssertThatWasUpdated(Classroom actualEntity, CreateClassromDto updateDto)
         {
-            Classroom classroom = new()
+            Assert.That(actualEntity.Name, Is.EqualTo(updateDto.Name));
+        }
+
+        /// <inheritdoc />
+        protected override int GetNonExistentId() => -1;
+
+        /// <inheritdoc />
+        protected override Classroom GetTestEntity()
+        {
+            return new()
             {
-                Name = "100"
+                Name = "#100"
             };
-            DbContext.Add(classroom);
-            await DbContext.SaveChangesAsync();
-
-            return classroom;
         }
 
-        private async Task<bool> ClassroomExists(int id)
+        /// <inheritdoc />
+        protected override CreateClassromDto GetValidCreateDto()
         {
-            return await DbContext.Set<Classroom>().AnyAsync(x => x.Id == id);
+            return new("#200");
         }
 
-        [SetUp]
-        public void SetUp()
+        /// <inheritdoc />
+        protected override CreateClassromDto GetValidUpdateDto()
         {
-            _classroomsService = ServiceScope.ServiceProvider.GetService<IClassroomsService>()!;
-        }
-
-        [Test]
-        public async Task GetById_ElementExists_ReturnsValidElement()
-        {
-            // Arrange
-            var classroom = await CreateDefaultClassroomAsync();
-            var expectedResult = classroom.Adapt<ViewClassroomDto>();
-
-            // Act
-            var result = await _classroomsService.GetByIdAsync(classroom.Id);
-
-            // Assert
-            Assert.That(result, Is.EqualTo(expectedResult));
-        }
-
-        [Test]
-        public async Task GetById_ElementDoesNotExist_ReturnsNull()
-        {
-            // Act
-            var result = await _classroomsService.GetByIdAsync(-1);
-
-            // Assert
-            Assert.That(result, Is.Null);
-        }
-
-        [Test]
-        public async Task Create_ValidInput_CreatesElement()
-        {
-            // Arrange
-            CreateClassromDto dto = new("Classroom Name");
-
-            // Act
-            int id = await _classroomsService.CreateAsync(dto);
-
-            // Assert(check if element is actually created)
-            Assert.That(await ClassroomExists(id));
-        }
-
-        [Test]
-        public async Task Update_ElementExists_Succeeds()
-        {
-            // Arrange
-            var classroom = await CreateDefaultClassroomAsync();
-            CreateClassromDto dto = new(classroom.Name + "2");
-            var expectedClassroom = dto.Adapt<Classroom>();
-
-            // Act
-            bool result = await _classroomsService.UpdateAsync(classroom.Id, dto);
-
-            // Assert
-            Assert.That(result);
-            var actualElement = await DbContext.Set<Classroom>()
-                .FirstOrDefaultAsync(c => c.Id == classroom.Id);
-            // Check if element was updated
-            Assert.That(actualElement, Is.Not.Null);
-            Assert.That(actualElement.Name, Is.EqualTo(dto.Name));
-        }
-
-        [Test]
-        public async Task Update_ElementDoesNotExist_ReturnFalse()
-        {
-            // Act
-            bool result = await _classroomsService.UpdateAsync(-1, DefaultCreateClassroomDto);
-
-            // Arrange
-            Assert.That(result, Is.False);
-        }
-
-        [Test]
-        public async Task Delete_ElementExists_Succeeds()
-        {
-            // Arrange
-            var classroom = await CreateDefaultClassroomAsync();
-
-            // Act
-            bool result = await _classroomsService.DeleteAsync(classroom.Id);
-
-            // Assert
-            Assert.That(result);
-            Assert.That(await ClassroomExists(classroom.Id), Is.False);
-        }
-
-        [Test]
-        public async Task Delete_ElementDoesNotExist_ReturnsFalse()
-        {
-            // Act
-            bool result = await _classroomsService.DeleteAsync(-1);
-
-            // Assert
-            Assert.That(result, Is.False);
+            return new("#300");
         }
     }
 }


### PR DESCRIPTION
This pull requests refactors both services and controllers tests.

### Changes
*  Created abstract classes `CrudControllersTest`, `AdminControllersTest` and `CrudServicesTest`.
* Refactored `ClassroomsServiceTests`, so it now inherits `CrudServicesTest`.
* Refactored `ClassroomsControllerTests`, so it now inherits `AdminControllersTest`.

### Additional notes
This approach increases Depth of Inheritance in integration testing, but reduces boilerplate code for testing the same CRUD opertations.