### PR TITLE
Resolve Negative Username Generation Issue

### DIFF
--- a/EUniversity.Tests/Services/AuthHelperTests.cs
+++ b/EUniversity.Tests/Services/AuthHelperTests.cs
@@ -7,6 +7,9 @@ namespace EUniversity.Tests.Services;
 
 public class AuthHelperTests
 {
+    // Seed used for mocking RandomNumberGenerator through Random
+    public const int RandomSeed = 50024030;
+
     private RandomNumberGenerator _rngMock;
     private UserManager<ApplicationUser> _userManagerMock;
 
@@ -15,15 +18,12 @@ public class AuthHelperTests
     {
         _rngMock = Substitute.For<RandomNumberGenerator>();
 
-        // GetBytes will return only zeros
+        // GetBytes will pseudorandom values controlled with a seed
+        Random random = new(RandomSeed);
         _rngMock.When(x => x.GetBytes(Arg.Any<byte[]>()))
             .Do(x =>
             {
-                var bytes = x.ArgAt<byte[]>(0);
-                for (int i = 0; i < bytes.Length; i++)
-                {
-                    bytes[i] = 0x00;
-                }
+                random.NextBytes(x.ArgAt<byte[]>(0));
             });
 
         // Mock user manager

--- a/Infrastructure/Services/Auth/AuthHelper.cs
+++ b/Infrastructure/Services/Auth/AuthHelper.cs
@@ -41,7 +41,7 @@ public class AuthHelper : IAuthHelper
             byte[] bytes = new byte[4];
             random.GetBytes(bytes);
             int rndInt = bytes[0] | bytes[1] << 8 | bytes[2] << 16 | bytes[3] << 24;
-            int rndNumber = rndInt % (max - min) + min;
+            int rndNumber = Math.Abs(rndInt) % (max - min) + min;
 
             // Username part based on first name and last name
             // (or just "u" if it cannot be created)


### PR DESCRIPTION
This pull request addresses the issue where the `AuthHelper.GenerateUserNameAsync` method occasionally generated usernames with negative number. The problem was caused by the `rndInt` variable occasionally being negative and not handling negative values as expected due to the `%` operator.

### Changes made
*  Mocked `RandomNumberGenerator` through the `Random` class with a pre-defined seed, ensuring consistent and predictable results during testing. Previously, zeros were used for testing instead.
*  Applied `Math.Abs` to a generated number.

Closes #27 