### PR TITLE
Update Validation Unit Tests Naming Convention

### DIFF
--- a/EUniversity.Tests/Validation/Auth/ChangePasswordDtoValidatorTests.cs
+++ b/EUniversity.Tests/Validation/Auth/ChangePasswordDtoValidatorTests.cs
@@ -19,7 +19,7 @@ public class ChangePasswordDtoValidatorTests
     }
 
     [Test]
-    public void Input_Valid_Succeeds()
+    public void Dto_Valid_Succeeds()
     {
         // Arrange
         ChangePasswordDto password = new(CurrentPassword, ValidNewPassword);
@@ -76,7 +76,7 @@ public class ChangePasswordDtoValidatorTests
     }
 
     [Test]
-    public void Passwords_Equal_Fails()
+    public void Passwords_Equal_FailsWithEqualError()
     {
         // Arrange
         ChangePasswordDto password = new(ValidNewPassword, ValidNewPassword);

--- a/EUniversity.Tests/Validation/Auth/LogInDtoValidatorTests.cs
+++ b/EUniversity.Tests/Validation/Auth/LogInDtoValidatorTests.cs
@@ -18,7 +18,7 @@ public class LogInDtoValidatorTests
     }
 
     [Test]
-    public void Input_Valid_IsValid()
+    public void Dto_Valid_Succeeds()
     {
         // Arrange
         LogInDto login = new(DefaultUserName, DefaultPassword, false);
@@ -31,7 +31,7 @@ public class LogInDtoValidatorTests
     }
 
     [Test]
-    public void UserName_Empty_IsInvalid()
+    public void UserName_Empty_FailsWithPropertyRequiredError()
     {
         // Arrange
         LogInDto login = new(string.Empty, DefaultPassword, false);

--- a/EUniversity.Tests/Validation/PaginationPropertiesValidatorTests.cs
+++ b/EUniversity.Tests/Validation/PaginationPropertiesValidatorTests.cs
@@ -18,7 +18,7 @@ public class PaginationPropertiesValidatorTests
     }
 
     [Test]
-    public void Input_Valid_IsValid()
+    public void Properties_Valid_Succeeds()
     {
         // Arrange
         PaginationProperties properties = new(ValidPage, ValidPageSize);
@@ -33,7 +33,7 @@ public class PaginationPropertiesValidatorTests
     [Test]
     [TestCase(0)]
     [TestCase(-3)]
-    public void Page_NotPositive_IsInvalid(int page)
+    public void Page_NotPositive_FailsWithPropertyTooSmallError(int page)
     {
         // Arrange
         PaginationProperties properties = new(page, ValidPageSize);
@@ -47,7 +47,7 @@ public class PaginationPropertiesValidatorTests
     }
 
     [Test]
-    public void PageSize_Small_IsInvalid()
+    public void PageSize_Small_FailsWithPropertyTooSmallError()
     {
         // Arrange
         PaginationProperties properties = new(ValidPage, PaginationProperties.MinPageSize - 1);
@@ -61,7 +61,7 @@ public class PaginationPropertiesValidatorTests
     }
 
     [Test]
-    public void PageSize_Large_IsInvalid()
+    public void PageSize_Large_FailsWithPropertyTooLargeError()
     {
         // Arrange
         PaginationProperties properties = new(ValidPage, PaginationProperties.MaxPageSize + 1);

--- a/EUniversity.Tests/Validation/University/ClassroomCreateDtoValidatorTests.cs
+++ b/EUniversity.Tests/Validation/University/ClassroomCreateDtoValidatorTests.cs
@@ -17,7 +17,7 @@ public class ClassroomCreateDtoValidatorTests
     }
 
     [Test]
-    public void Name_Valid_IsValid()
+    public void Dto_Valid_Succeeds()
     {
         // Arrange
         ClassroomCreateDto dto = new("Room 115");
@@ -30,7 +30,7 @@ public class ClassroomCreateDtoValidatorTests
     }
 
     [Test]
-    public void Name_TooLarge_IsInvalid()
+    public void Name_TooLarge_FailsWithPropertyTooLargeError()
     {
         // Arrange
         ClassroomCreateDto dto = new(new string('0', Classroom.MaxNameLength + 1));
@@ -44,7 +44,7 @@ public class ClassroomCreateDtoValidatorTests
     }
 
     [Test]
-    public void Name_Empty_IsInvalid()
+    public void Name_Empty_FailsWithPropertyRequiredError()
     {
         // Arrange
         ClassroomCreateDto dto = new(string.Empty);

--- a/EUniversity.Tests/Validation/University/CourseCreateDtoValidatorTests.cs
+++ b/EUniversity.Tests/Validation/University/CourseCreateDtoValidatorTests.cs
@@ -20,7 +20,7 @@ public class CourseCreateDtoValidatorTests
     }
 
     [Test]
-    public void Dto_Valid_IsValid()
+    public void Dto_Valid_Succeeds()
     {
         // Arrange
         CourseCreateDto dto = new(DefaultName, DefaultDescription);
@@ -33,7 +33,7 @@ public class CourseCreateDtoValidatorTests
     }
 
     [Test]
-    public void Name_TooLarge_IsInvalid()
+    public void Name_TooLarge_FailsWithPropertyTooLargeError()
     {
         // Arrange
         CourseCreateDto dto = new(new string('0', Course.MaxNameLength + 1), DefaultDescription);
@@ -47,7 +47,7 @@ public class CourseCreateDtoValidatorTests
     }
 
     [Test]
-    public void Name_Empty_IsInvalid()
+    public void Name_Empty_FailsWithPropertyRequiredError()
     {
         // Arrange
         CourseCreateDto dto = new(string.Empty, DefaultDescription);
@@ -63,7 +63,7 @@ public class CourseCreateDtoValidatorTests
     [Test]
     [TestCase(null)]
     [TestCase("")]
-    public void Description_NullOrEmpty_IsValid(string? description)
+    public void Description_NullOrEmpty_Succeeds(string? description)
     {
         // Arrange
         CourseCreateDto dto = new(DefaultName, description);
@@ -76,7 +76,7 @@ public class CourseCreateDtoValidatorTests
     }
 
     [Test]
-    public void Description_TooLarge_IsInvalid()
+    public void Description_TooLarge_FailsWithPropertyTooLargeError()
     {
         // Arrange
         CourseCreateDto dto = new(DefaultName, new string('0', Course.MaxDescriptionLength + 1));

--- a/EUniversity.Tests/Validation/University/Grades/GradeDtoValidatorTests.cs
+++ b/EUniversity.Tests/Validation/University/Grades/GradeDtoValidatorTests.cs
@@ -20,7 +20,7 @@ internal class GradeDtoValidatorTests
     }
 
     [Test]
-    public void Name_Valid_IsValid()
+    public void Name_Valid_Succeeds()
     {
         // Arrange
         GradeCreateDto dto = new(DefaultName, DefaultScore);
@@ -33,7 +33,7 @@ internal class GradeDtoValidatorTests
     }
 
     [Test]
-    public void Name_TooLarge_IsInvalid()
+    public void Name_TooLarge_FailsWithPropertyTooLargeError()
     {
         // Arrange
         GradeCreateDto dto = new(new string('0', Grade.MaxNameLength + 1), DefaultScore);
@@ -47,7 +47,7 @@ internal class GradeDtoValidatorTests
     }
 
     [Test]
-    public void Name_Empty_IsInvalid()
+    public void Name_Empty_FailsWithPropertyRequiredError()
     {
         // Arrange
         GradeCreateDto dto = new(string.Empty, DefaultScore);

--- a/EUniversity.Tests/Validation/Users/RegisterDtoValidatorTests.cs
+++ b/EUniversity.Tests/Validation/Users/RegisterDtoValidatorTests.cs
@@ -39,7 +39,7 @@ public class RegisterDtoValidatorTests
     }
 
     [Test]
-    public void Email_TooLarge_Fails()
+    public void Email_TooLarge_FailsWithPropertyTooLargeError()
     {
         // Arrange
         string bigString = new('a', ApplicationUser.MaxEmailLength);
@@ -56,7 +56,7 @@ public class RegisterDtoValidatorTests
     }
 
     [Test]
-    public void Email_Empty_Fails()
+    public void Email_Empty_FailsWithPropertyRequiredError()
     {
         // Arrange
         RegisterDto register = new(string.Empty, DefaultFirstName, DefaultLastName, DefaultMiddleName);
@@ -71,7 +71,7 @@ public class RegisterDtoValidatorTests
     }
 
     [Test]
-    public void Email_Invalid_Fails()
+    public void Email_Invalid_FailsWithInvalidEmailError()
     {
         // Arrange
         RegisterDto register = new("invalid", DefaultFirstName, DefaultLastName, DefaultMiddleName);
@@ -104,7 +104,7 @@ public class RegisterDtoValidatorTests
     }
 
     [Test]
-    public void FirstName_Empty_Fails()
+    public void FirstName_Empty_FailsWithPropertyRequiredError()
     {
         // Arrange
         RegisterDto register = new(DefaultEmail, string.Empty, DefaultLastName, DefaultMiddleName);
@@ -119,7 +119,7 @@ public class RegisterDtoValidatorTests
     }
 
     [Test]
-    public void FirstName_TooLarge_Fails()
+    public void FirstName_TooLarge_FailsWithPropertyTooLargeError()
     {
         // Arrange
         string bigFirstName = new('a', ApplicationUser.MaxNameLength + 1);
@@ -153,7 +153,7 @@ public class RegisterDtoValidatorTests
     }
 
     [Test]
-    public void LastName_Empty_Fails()
+    public void LastName_Empty_FailsWithPropertyRequiredError()
     {
         // Arrange
         RegisterDto register = new(DefaultEmail, DefaultFirstName, string.Empty, DefaultMiddleName);
@@ -168,7 +168,7 @@ public class RegisterDtoValidatorTests
     }
 
     [Test]
-    public void LastName_TooLarge_Fails()
+    public void LastName_TooLarge_FailsWithPropertyTooLargeError()
     {
         // Arrange
         string bigLastName = new('a', ApplicationUser.MaxNameLength + 1);
@@ -216,7 +216,7 @@ public class RegisterDtoValidatorTests
     }
 
     [Test]
-    public void MiddleName_TooLarge_Fails()
+    public void MiddleName_TooLarge_FailsWithPropertyTooLargeError()
     {
         // Arrange
         string bigMiddleName = new('a', ApplicationUser.MaxNameLength + 1);

--- a/EUniversity.Tests/Validation/Users/RegisterUsersDtoValidatorTests.cs
+++ b/EUniversity.Tests/Validation/Users/RegisterUsersDtoValidatorTests.cs
@@ -19,7 +19,7 @@ public class RegisterUsersDtoValidatorTests
     }
 
     [Test]
-    public void Dtos_ValidChildren_IsValid()
+    public void Dtos_ValidChildren_Succeed()
     {
         // Arrange
         RegisterUsersDto dto = new(new RegisterDto[1] { _validRegisterDto });
@@ -32,7 +32,7 @@ public class RegisterUsersDtoValidatorTests
     }
 
     [Test]
-    public void Dtos_Empty_IsInvalid()
+    public void Dtos_Empty_FailsWithEmptyCollectionError()
     {
         // Arrange
         RegisterUsersDto dto = new(Enumerable.Empty<RegisterDto>());
@@ -47,7 +47,7 @@ public class RegisterUsersDtoValidatorTests
     }
 
     [Test]
-    public void Dtos_InvalidChildElement_IsInvalid()
+    public void Dtos_InvalidChildElement_Fails()
     {
         // Arrange
         RegisterUsersDto users = new(


### PR DESCRIPTION
This pull request updates naming convention for unit tests related to validation. All unit tests in the `EUniversity.Tests.Validation` namespace were affected.

#### Old naming convention:
* `Dto_Valid_IsValid`
* `Name_Empty_IsInvalid`
#### New naming convention:
* `Dto_Valid_Succeeds`
* `Name_Empty_FailsWithPropertyEmptyError`

Closes #30