### PR TITLE
Add ID Property to User DTOs

### DIFF
--- a/Core/Dtos/Users/CreatedUserDto.cs
+++ b/Core/Dtos/Users/CreatedUserDto.cs
@@ -1,3 +1,3 @@
 ﻿namespace EUniversity.Core.Dtos.Users;
 
-public record CreatedUserDto(string UserName, string Password, bool Success, IEnumerable<string>? Errors);
+public record CreatedUserDto(string Id, string UserName, string Password, bool Success, IEnumerable<string>? Errors);

--- a/Core/Dtos/Users/StudentPreviewDto.cs
+++ b/Core/Dtos/Users/StudentPreviewDto.cs
@@ -1,3 +1,3 @@
 ﻿namespace EUniversity.Core.Dtos.Users;
 
-public record StudentPreviewDto(string UserName, string FirstName, string LastName, string? MiddleName);
+public record StudentPreviewDto(string Id, string UserName, string FirstName, string LastName, string? MiddleName);

--- a/Core/Dtos/Users/TeacherPreviewDto.cs
+++ b/Core/Dtos/Users/TeacherPreviewDto.cs
@@ -1,3 +1,3 @@
 ﻿namespace EUniversity.Core.Dtos.Users;
 
-public record TeacherPreviewDto(string UserName, string FirstName, string LastName, string? MiddleName);
+public record TeacherPreviewDto(string Id, string UserName, string FirstName, string LastName, string? MiddleName);

--- a/Core/Dtos/Users/UserViewDto.cs
+++ b/Core/Dtos/Users/UserViewDto.cs
@@ -1,3 +1,3 @@
 ﻿namespace EUniversity.Core.Dtos.Users;
 
-public record UserViewDto(string Email, string UserName, string FirstName, string LastName, string? MiddleName);
+public record UserViewDto(string Id, string Email, string UserName, string FirstName, string LastName, string? MiddleName);

--- a/Core/Services/Auth/RegisterResult.cs
+++ b/Core/Services/Auth/RegisterResult.cs
@@ -8,7 +8,7 @@ namespace EUniversity.Core.Services.Auth;
 public class RegisterResult
 {
     private readonly IdentityResult _identityResult;
-    private readonly string? _userName, _password;
+    private readonly string? _id, _userName, _password;
 
     /// <inheritdoc cref="IdentityResult.Succeeded" />
     public bool Succeeded => _identityResult.Succeeded;
@@ -16,6 +16,14 @@ public class RegisterResult
     /// <inheritdoc cref="IdentityResult.Errors" />
     public IEnumerable<IdentityError> Errors => _identityResult.Errors;
 
+    /// <summary>
+    /// ID of the registered user. 
+    /// <see langword="null" /> on failure.
+    /// </summary>
+    /// <value>
+    /// <see langword="null" /> when <see cref="Succeeded" /> is <see langword="false" />.
+    /// </value>
+    public string Id => _id!;
     /// <summary>
     /// Username of the registered user. 
     /// </summary>
@@ -33,11 +41,12 @@ public class RegisterResult
     public string Password => _password!;
 
     public RegisterResult(IdentityResult result,
-        string? userName = null, string? password = null)
+        string? id = null, string? userName = null, string? password = null)
     {
         _identityResult = result;
         if (result.Succeeded)
         {
+            _id = id;
             _userName = userName;
             _password = password;
         }

--- a/EUniversity/Controllers/UsersController.cs
+++ b/EUniversity/Controllers/UsersController.cs
@@ -80,6 +80,7 @@ public class UsersController : ControllerBase
         await foreach (var result in _authService.RegisterManyAsync(students.Users, role))
         {
             CreatedUserDto createdUser = new(
+                result.Id,
                 result.UserName,
                 result.Password,
                 result.Succeeded,

--- a/Infrastructure/Services/Auth/AuthService.cs
+++ b/Infrastructure/Services/Auth/AuthService.cs
@@ -50,7 +50,7 @@ public class AuthService : IAuthService
         }
 
         var roleResult = await _userManager.AddToRolesAsync(user, roles);
-        return new(roleResult, userName, password);
+        return new(roleResult, user.Id, userName, password);
     }
 
     /// <inheritdoc />

--- a/IntegrationTests/Controllers/University/GroupsControllerTests.cs
+++ b/IntegrationTests/Controllers/University/GroupsControllerTests.cs
@@ -7,7 +7,7 @@ namespace EUniversity.IntegrationTests.Controllers.University;
 public class GroupsControllerTests :
     CrudControllersTest<Group, int, GroupPreviewDto, GroupViewDto, GroupCreateDto, GroupCreateDto>
 {
-    public readonly TeacherPreviewDto TeacherPreviewDto = new("test-teacher", "Teacher1", "Teacher2", null);
+    public readonly TeacherPreviewDto TeacherPreviewDto = new(Guid.NewGuid().ToString(), "test-teacher", "Teacher1", "Teacher2", null);
     public readonly CoursePreviewDto CoursePreviewDto = new(5, "Some Course");
 
     public override string GetPageRoute => "api/groups";
@@ -54,7 +54,7 @@ public class GroupsControllerTests :
     {
         List<StudentPreviewDto> students = new() 
         { 
-            new("test-user", "Student1", "Student2", null) 
+            new(Guid.NewGuid().ToString(), "test-user", "Student1", "Student2", null) 
         };
         return new(DefaultId, "Group", TeacherPreviewDto, 
             CoursePreviewDto, students);


### PR DESCRIPTION
This pull request introduces an 'ID' property to enhance the functionality of DTOs associated with user views. The affected DTOs include:

* `CreatedUserDto`
* `StudentPreviewDto`
* `TeacherPreviewDto`
* `UserViewDto`

### Motivation
This change is motivated by the need for improved readability and compatibility with the 'api/groups' endpoints. These endpoints require the use of user IDs to establish relationships between groups and users, specifically for a teacher and students.