### PR TITLE
Enhance CRUD posts methods

### DIFF
--- a/Core/Services/ICrudService.cs
+++ b/Core/Services/ICrudService.cs
@@ -45,9 +45,9 @@ public interface ICrudService<TEntity, TId, TPreviewDto, TDetailsDto, TCreateDto
     /// <param name="dto">The DTO containing data for creating the entity.</param>
     /// <returns>
     /// A task that represents the asynchronous operation, containing
-    /// the identifier of the newly created entity.
+    /// the newly created entity.
     /// </returns>
-    Task<TId> CreateAsync(TCreateDto dto);
+    Task<TEntity> CreateAsync(TCreateDto dto);
 
     /// <summary>
     /// Updates an existing entity identified by its unique identifier asynchronously.

--- a/EUniversity/Controllers/University/ClassroomsController.cs
+++ b/EUniversity/Controllers/University/ClassroomsController.cs
@@ -2,6 +2,7 @@
 using EUniversity.Core.Pagination;
 using EUniversity.Core.Policy;
 using EUniversity.Infrastructure.Services.University;
+using Mapster;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SharpGrip.FluentValidation.AutoValidation.Mvc.Attributes;
@@ -70,15 +71,15 @@ public class ClassroomsController : ControllerBase
     /// <response code="403">User lacks 'Administrator' role</response>
     [HttpPost]
     [Authorize(Policies.HasAdministratorPermission)]
-    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ClassroomViewDto), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> CreateClassroomAsync([FromBody] ClassroomCreateDto dto)
     {
-        int id = await _classroomsService.CreateAsync(dto);
-        var routeValues = new { id };
-        var body = new { id };
+        var classroom = await _classroomsService.CreateAsync(dto);
+        var routeValues = new { id = classroom.Id };
+        var body = classroom.Adapt<ClassroomViewDto>();
         return CreatedAtRoute(nameof(GetClassroomByIdAsync), routeValues, body);
     }
 

--- a/EUniversity/Controllers/University/CoursesController.cs
+++ b/EUniversity/Controllers/University/CoursesController.cs
@@ -2,6 +2,7 @@
 using EUniversity.Core.Pagination;
 using EUniversity.Core.Policy;
 using EUniversity.Core.Services.University;
+using Mapster;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SharpGrip.FluentValidation.AutoValidation.Mvc.Attributes;
@@ -70,15 +71,15 @@ public class CoursesController : ControllerBase
     /// <response code="403">User lacks 'Administrator' role</response>
     [HttpPost]
     [Authorize(Policies.HasAdministratorPermission)]
-    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(CourseViewDto), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> CreateCourseAsync([FromBody] CourseCreateDto dto)
     {
-        int id = await _coursesService.CreateAsync(dto);
-        var routeValues = new { id };
-        var body = new { id };
+        var course = await _coursesService.CreateAsync(dto);
+        var routeValues = new { id = course.Id };
+        var body = course.Adapt<CourseViewDto>();
         return CreatedAtRoute(nameof(GetCourseByIdAsync), routeValues, body);
     }
 

--- a/EUniversity/Controllers/University/Grades/GradesController.cs
+++ b/EUniversity/Controllers/University/Grades/GradesController.cs
@@ -2,6 +2,7 @@
 using EUniversity.Core.Pagination;
 using EUniversity.Core.Policy;
 using EUniversity.Infrastructure.Services.University;
+using Mapster;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SharpGrip.FluentValidation.AutoValidation.Mvc.Attributes;
@@ -70,15 +71,15 @@ public class GradesController : ControllerBase
     /// <response code="403">User lacks 'Administrator' role</response>
     [HttpPost]
     [Authorize(Policies.HasAdministratorPermission)]
-    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(GradeViewDto), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> CreateGradeAsync([FromBody] GradeCreateDto dto)
     {
-        int id = await _gradesService.CreateAsync(dto);
-        var routeValues = new { id };
-        var body = new { id };
+        var grade = await _gradesService.CreateAsync(dto);
+        var routeValues = new { id = grade.Id };
+        var body = grade.Adapt<GradeViewDto>();
         return CreatedAtRoute(nameof(GetGradeByIdAsync), routeValues, body);
     }
 

--- a/EUniversity/Controllers/University/GroupsController.cs
+++ b/EUniversity/Controllers/University/GroupsController.cs
@@ -5,6 +5,7 @@ using EUniversity.Core.Pagination;
 using EUniversity.Core.Policy;
 using EUniversity.Core.Services;
 using EUniversity.Core.Services.University;
+using Mapster;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SharpGrip.FluentValidation.AutoValidation.Mvc.Attributes;
@@ -77,15 +78,15 @@ public class GroupsController : ControllerBase
     /// <response code="403">User lacks 'Administrator' role</response>
     [HttpPost]
     [Authorize(Policies.HasAdministratorPermission)]
-    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(GroupViewDto), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> CreateGroupAsync([FromBody] GroupCreateDto dto)
     {
-        int id = await _groupsService.CreateAsync(dto);
-        var routeValues = new { id };
-        var body = new { id };
+        var group = await _groupsService.CreateAsync(dto);
+        var routeValues = new { id = group.Id };
+        var body = group.Adapt<GroupViewDto>();
         return CreatedAtRoute(nameof(GetGroupByIdAsync), routeValues, body);
     }
 

--- a/Infrastructure/Services/BaseCrudService.cs
+++ b/Infrastructure/Services/BaseCrudService.cs
@@ -45,13 +45,13 @@ public abstract class BaseCrudService<TEntity, TId, TPreviewDto, TDetailsDto, TC
     }
 
     /// <inheritdoc />
-    public virtual async Task<TId> CreateAsync(TCreateDto dto)
+    public virtual async Task<TEntity> CreateAsync(TCreateDto dto)
     {
         TEntity entity = dto.Adapt<TEntity>();
         DbContext.Set<TEntity>().Add(entity);
         await DbContext.SaveChangesAsync();
 
-        return entity.Id;
+        return entity;
     }
 
     /// <inheritdoc />

--- a/IntegrationTests/Controllers/CrudControllersTest.cs
+++ b/IntegrationTests/Controllers/CrudControllersTest.cs
@@ -2,7 +2,6 @@
 using EUniversity.Core.Models;
 using EUniversity.Core.Pagination;
 using EUniversity.Core.Services;
-using EUniversity.IntegrationTests.Mocks;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using NSubstitute.ReturnsExtensions;

--- a/IntegrationTests/Controllers/CrudControllersTest.cs
+++ b/IntegrationTests/Controllers/CrudControllersTest.cs
@@ -248,7 +248,7 @@ public abstract class CrudControllersTest<TEntity, TId, TPreviewDto, TDetailsDto
         using var client = GetTestClient();
         ServiceMock
             .CreateAsync(Arg.Any<TCreateDto>())
-            .Returns(DefaultId);
+            .Returns(Activator.CreateInstance<TEntity>());
 
         // Act
         var result = await client.PostAsJsonAsync(PostRoute, validCreateDto);

--- a/IntegrationTests/Controllers/University/StudentGroupsEndpointsTests.cs
+++ b/IntegrationTests/Controllers/University/StudentGroupsEndpointsTests.cs
@@ -1,8 +1,6 @@
 ﻿using EUniversity.Core.Dtos.University;
 using EUniversity.Core.Models;
 using EUniversity.Core.Models.University;
-using EUniversity.Core.Services.University;
-using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using System.Net;

--- a/IntegrationTests/Services/CrudServicesTest.cs
+++ b/IntegrationTests/Services/CrudServicesTest.cs
@@ -183,10 +183,10 @@ public abstract class CrudServicesTest<TService, TEntity, TId, TPreviewDto, TDet
         TCreateDto dto = GetValidCreateDto();
 
         // Act
-        TId id = await Service.CreateAsync(dto);
+        TEntity entity = await Service.CreateAsync(dto);
 
         // Assert(check if element is actually created)
-        Assert.That(await EntityExistsAsync(id), "Entity doesn't exist");
+        Assert.That(await EntityExistsAsync(entity.Id), "Entity doesn't exist");
     }
 
     [Test]


### PR DESCRIPTION
This pull requests changes response bodies of all HTTP POST methods related to university entities. Now the response body of each HTTP POST method contains newly created entity instead of just ID.

### Changes made
* `ICrudService.CreateAsync` return type was changed from `TId` to `TEntity`.
* All university entities related POST methods(except for `api/groups/{groupId:int}/students`) were configured to return newly created entity.