### PR TITLE
Add Name Filters

### DIFF
--- a/Core/Filters/NameFilter.cs
+++ b/Core/Filters/NameFilter.cs
@@ -1,0 +1,36 @@
+﻿using EUniversity.Core.Models;
+
+namespace EUniversity.Core.Filters;
+
+/// <summary>
+/// Filter that filters entities by their names.
+/// </summary>
+/// <typeparam name="T">The type of entities to filter, which must implement the <see cref="IHasName" />  interface.</typeparam>
+public class NameFilter<T> : IFilter<T> where T : IHasName
+{
+    /// <summary>
+    /// Gets the name to filter by.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the NameFilter class with the specified name.
+    /// </summary>
+    /// <param name="name">The name to filter by.</param>
+    public NameFilter(string name)
+    {
+        Name = name;
+    }
+
+    /// <summary>
+    /// Apply the name filter to a query.
+    /// </summary>
+    /// <param name="query">The query that needs to be filtered.</param>
+    /// <returns>
+    /// Filtered query that contains entities with a matched name.
+    /// </returns>
+    public IQueryable<T> Apply(IQueryable<T> query)
+    {
+        return query.Where(x => x.Name.Contains(Name));
+    }
+}

--- a/Core/Models/IHasName.cs
+++ b/Core/Models/IHasName.cs
@@ -8,5 +8,5 @@ public interface IHasName
     /// <summary>
     /// The name of the object.
     /// </summary>
-    string Name { get; set; }
+    string Name { get; }
 }

--- a/Core/Models/IHasName.cs
+++ b/Core/Models/IHasName.cs
@@ -1,0 +1,12 @@
+﻿namespace EUniversity.Core.Models;
+
+/// <summary>
+/// An interface that defines an object that have a Name property.
+/// </summary>
+public interface IHasName
+{
+    /// <summary>
+    /// The name of the object.
+    /// </summary>
+    string Name { get; set; }
+}

--- a/Core/Models/University/Classroom.cs
+++ b/Core/Models/University/Classroom.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Represents a classroom entity.
 /// </summary>
-public class Classroom : IEntity<int>
+public class Classroom : IEntity<int>, IHasName
 {
     public const int MaxNameLength = 50;
 

--- a/Core/Models/University/Course.cs
+++ b/Core/Models/University/Course.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Represents a course entity.
 /// </summary>
-public class Course : IEntity<int>
+public class Course : IEntity<int>, IHasName
 {
     public const int MaxNameLength = 200;
     public const int MaxDescriptionLength = 1000;

--- a/Core/Models/University/Grades/Grade.cs
+++ b/Core/Models/University/Grades/Grade.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Represents an available grade entity that can be assigned to students.
 /// </summary>
-public class Grade : IEntity<int>
+public class Grade : IEntity<int>, IHasName
 {
     public const int MaxNameLength = 50;
 

--- a/Core/Models/University/Group.cs
+++ b/Core/Models/University/Group.cs
@@ -6,7 +6,7 @@ namespace EUniversity.Core.Models.University;
 /// Represents a group entity, 
 /// which contains students with its own teacher and course.
 /// </summary>
-public class Group : IEntity<int>
+public class Group : IEntity<int>, IHasName
 {
     public const int MaxNameLength = 50;
 

--- a/Core/Pagination/PaginationProperties.cs
+++ b/Core/Pagination/PaginationProperties.cs
@@ -1,5 +1,10 @@
 ﻿namespace EUniversity.Core.Pagination;
 
+/// <summary>
+/// Represents the pagination properties for a collection of items.
+/// </summary>
+/// <param name="Page">The page number. Default is 1.</param>
+/// <param name="PageSize">The number of items per page. Default is 20.</param>
 public record PaginationProperties(int Page = 1, int PageSize = 20)
 {
     public const int MinPageSize = 5;

--- a/EUniversity.Tests/Filters/NameFilterTests.cs
+++ b/EUniversity.Tests/Filters/NameFilterTests.cs
@@ -1,0 +1,52 @@
+﻿using EUniversity.Core.Filters;
+using EUniversity.Core.Models;
+
+namespace EUniversity.Tests.Filters;
+
+public class NameFilterTests
+{
+    private record NamedEntity(string Name) : IHasName;
+
+    [Test]
+    public void EmptyFilter_ReturnsEntireQuery()
+    {
+        // Arrange
+        NameFilter<NamedEntity> filter = new(string.Empty);
+        NamedEntity[] array = { new("Cucumber"), new("Apple"), new("Tomato"), new("Banana") };
+
+        // Act
+        var result = filter.Apply(array.AsQueryable());
+
+        // Assert
+        Assert.That(result, Is.EquivalentTo(array));
+    }
+
+    [Test]
+    public void FilterSpecified_ReturnsFilteredQuery()
+    {
+        // Arrange
+        NameFilter<NamedEntity> filter = new("berry");
+        NamedEntity[] sourceArray = { new("Blueberry"), new("Grape"), new("Blackberry"), new("Cherry"), new("Strawberry") };
+        NamedEntity[] expectedArray = { new("Blueberry"), new("Strawberry"), new("Blackberry") };
+
+        // Act
+        var result = filter.Apply(sourceArray.AsQueryable());
+
+        // Assert
+        Assert.That(result, Is.EquivalentTo(expectedArray));
+    }
+
+    [Test]
+    public void FilterSpecified_NoMatches_ReturnsEmptyQuery()
+    {
+        // Arrange
+        NameFilter<NamedEntity> filter = new("Orange");
+        NamedEntity[] array = { new("Cucumber"), new("Apple"), new("Tomato"), new("Banana") };
+
+        // Act
+        var result = filter.Apply(array.AsQueryable());
+
+        // Assert
+        Assert.That(result, Is.Empty);
+    }
+}

--- a/EUniversity/Controllers/University/ClassroomsController.cs
+++ b/EUniversity/Controllers/University/ClassroomsController.cs
@@ -32,6 +32,8 @@ public class ClassroomsController : ControllerBase
     /// <remarks>
     /// If there is no items in the requested page, then empty page will be returned.
     /// </remarks>
+    /// <param name="properties">Pagination properties.</param>
+    /// <param name="name">An optional name to filter classrooms by.</param>
     /// <response code="200">Returns requested page with classrooms.</response>
     /// <response code="400">Bad request</response>
     /// <response code="401">Unauthorized user call</response>

--- a/EUniversity/Controllers/University/ClassroomsController.cs
+++ b/EUniversity/Controllers/University/ClassroomsController.cs
@@ -1,4 +1,6 @@
 ﻿using EUniversity.Core.Dtos.University;
+using EUniversity.Core.Filters;
+using EUniversity.Core.Models.University;
 using EUniversity.Core.Pagination;
 using EUniversity.Core.Policy;
 using EUniversity.Infrastructure.Services.University;
@@ -38,9 +40,12 @@ public class ClassroomsController : ControllerBase
     [ProducesResponseType(typeof(Page<ClassroomViewDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    public async Task<IActionResult> GetClassroomsPageAsync([FromQuery] PaginationProperties properties)
+    public async Task<IActionResult> GetClassroomsPageAsync(
+        [FromQuery] PaginationProperties properties, 
+        [FromQuery] string? name)
     {
-        return Ok(await _classroomsService.GetPageAsync(properties));
+        NameFilter<Classroom>? filter = name != null ? new(name) : null;
+        return Ok(await _classroomsService.GetPageAsync(properties, filter));
     }
 
     /// <summary>

--- a/EUniversity/Controllers/University/CoursesController.cs
+++ b/EUniversity/Controllers/University/CoursesController.cs
@@ -33,6 +33,8 @@ public class CoursesController : ControllerBase
     /// <remarks>
     /// If there is no items in the requested page, then empty page will be returned.
     /// </remarks>
+    /// <param name="properties">Pagination properties.</param>
+    /// <param name="name">An optional name to filter courses by.</param>
     /// <response code="200">Returns requested page with courses.</response>
     /// <response code="400">Bad request</response>
     /// <response code="401">Unauthorized user call</response>

--- a/EUniversity/Controllers/University/CoursesController.cs
+++ b/EUniversity/Controllers/University/CoursesController.cs
@@ -1,4 +1,7 @@
-﻿using EUniversity.Core.Dtos.University;
+﻿using Bogus.DataSets;
+using EUniversity.Core.Dtos.University;
+using EUniversity.Core.Filters;
+using EUniversity.Core.Models.University;
 using EUniversity.Core.Pagination;
 using EUniversity.Core.Policy;
 using EUniversity.Core.Services.University;
@@ -38,9 +41,12 @@ public class CoursesController : ControllerBase
     [ProducesResponseType(typeof(Page<CourseViewDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    public async Task<IActionResult> GetCoursesPageAsync([FromQuery] PaginationProperties properties)
+    public async Task<IActionResult> GetCoursesPageAsync(
+        [FromQuery] PaginationProperties properties,
+        [FromQuery] string? name)
     {
-        return Ok(await _coursesService.GetPageAsync(properties));
+        NameFilter<Course>? filter = name != null ? new(name) : null;
+        return Ok(await _coursesService.GetPageAsync(properties, filter));
     }
 
     /// <summary>

--- a/EUniversity/Controllers/University/Grades/GradesController.cs
+++ b/EUniversity/Controllers/University/Grades/GradesController.cs
@@ -1,4 +1,8 @@
-﻿using EUniversity.Core.Dtos.University.Grades;
+﻿using Bogus.DataSets;
+using EUniversity.Core.Dtos.University.Grades;
+using EUniversity.Core.Filters;
+using EUniversity.Core.Models.University;
+using EUniversity.Core.Models.University.Grades;
 using EUniversity.Core.Pagination;
 using EUniversity.Core.Policy;
 using EUniversity.Infrastructure.Services.University;
@@ -38,9 +42,12 @@ public class GradesController : ControllerBase
     [ProducesResponseType(typeof(Page<GradeCreateDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    public async Task<IActionResult> GetGradesPageAsync([FromQuery] PaginationProperties properties)
+    public async Task<IActionResult> GetGradesPageAsync(
+        [FromQuery] PaginationProperties properties,
+        [FromQuery] string? name)
     {
-        return Ok(await _gradesService.GetPageAsync(properties));
+        NameFilter<Grade>? filter = name != null ? new(name) : null;
+        return Ok(await _gradesService.GetPageAsync(properties, filter));
     }
 
     /// <summary>

--- a/EUniversity/Controllers/University/Grades/GradesController.cs
+++ b/EUniversity/Controllers/University/Grades/GradesController.cs
@@ -34,6 +34,8 @@ public class GradesController : ControllerBase
     /// <remarks>
     /// If there is no items in the requested page, then empty page will be returned.
     /// </remarks>
+    /// <param name="properties">Pagination properties.</param>
+    /// <param name="name">An optional name to filter grades by.</param>
     /// <response code="200">Returns requested page with grades.</response>
     /// <response code="400">Bad request</response>
     /// <response code="401">Unauthorized user call</response>

--- a/EUniversity/Controllers/University/GroupsController.cs
+++ b/EUniversity/Controllers/University/GroupsController.cs
@@ -39,6 +39,8 @@ public class GroupsController : ControllerBase
     /// <remarks>
     /// If there is no items in the requested page, then empty page will be returned.
     /// </remarks>
+    /// <param name="properties">Pagination properties.</param>
+    /// <param name="name">An optional name to filter groups by.</param>
     /// <response code="200">Returns requested page with groups.</response>
     /// <response code="400">Bad request</response>
     /// <response code="401">Unauthorized user call</response>

--- a/EUniversity/Controllers/University/GroupsController.cs
+++ b/EUniversity/Controllers/University/GroupsController.cs
@@ -1,4 +1,6 @@
-﻿using EUniversity.Core.Dtos.University;
+﻿using Bogus.DataSets;
+using EUniversity.Core.Dtos.University;
+using EUniversity.Core.Filters;
 using EUniversity.Core.Models;
 using EUniversity.Core.Models.University;
 using EUniversity.Core.Pagination;
@@ -45,9 +47,12 @@ public class GroupsController : ControllerBase
     [ProducesResponseType(typeof(Page<GroupViewDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    public async Task<IActionResult> GetGroupsPageAsync([FromQuery] PaginationProperties properties)
+    public async Task<IActionResult> GetGroupsPageAsync(
+        [FromQuery] PaginationProperties properties,
+        [FromQuery] string? name)
     {
-        return Ok(await _groupsService.GetPageAsync(properties));
+        NameFilter<Group>? filter = name != null ? new(name) : null;
+        return Ok(await _groupsService.GetPageAsync(properties, filter));
     }
 
     /// <summary>

--- a/IntegrationTests/Controllers/University/ClassroomsControllerTests.cs
+++ b/IntegrationTests/Controllers/University/ClassroomsControllerTests.cs
@@ -1,5 +1,7 @@
 ﻿using EUniversity.Core.Dtos.University;
+using EUniversity.Core.Filters;
 using EUniversity.Core.Models.University;
+using NUnit.Framework.Internal;
 
 namespace EUniversity.IntegrationTests.Controllers.University;
 
@@ -17,6 +19,8 @@ public class ClassroomsControllerTests :
     public override string DeleteRoute => $"api/classrooms/{DefaultId}";
 
     public override int DefaultId => 1;
+
+    public override string GetPageFilter => "name=testfilter";
 
     public override void SetUpService()
     {
@@ -51,5 +55,10 @@ public class ClassroomsControllerTests :
     protected override ClassroomCreateDto GetValidUpdateDto()
     {
         return new("#200");
+    }
+
+    protected override bool AssertThatFilterWasApplied(IFilter<Classroom> filter)
+    {
+        return filter is NameFilter<Classroom> nameFilter && nameFilter.Name == "testfilter";
     }
 }

--- a/IntegrationTests/Controllers/University/CoursesControllerTests.cs
+++ b/IntegrationTests/Controllers/University/CoursesControllerTests.cs
@@ -1,4 +1,5 @@
 ﻿using EUniversity.Core.Dtos.University;
+using EUniversity.Core.Filters;
 using EUniversity.Core.Models.University;
 
 namespace EUniversity.IntegrationTests.Controllers.University;
@@ -18,9 +19,16 @@ public class CoursesControllerTests :
 
     public override int DefaultId => 1;
 
+    public override string GetPageFilter => "name=testfilter";
+
     public override void SetUpService()
     {
         ServiceMock = WebApplicationFactory.CoursesServiceMock;
+    }
+
+    protected override bool AssertThatFilterWasApplied(IFilter<Course> filter)
+    {
+        return filter is NameFilter<Course> nameFilter && nameFilter.Name == "testfilter";
     }
 
     protected override CourseCreateDto GetInvalidCreateDto()

--- a/IntegrationTests/Controllers/University/Grades/GradesControllerTests.cs
+++ b/IntegrationTests/Controllers/University/Grades/GradesControllerTests.cs
@@ -1,4 +1,6 @@
 ﻿using EUniversity.Core.Dtos.University.Grades;
+using EUniversity.Core.Filters;
+using EUniversity.Core.Models.University;
 using EUniversity.Core.Models.University.Grades;
 
 namespace EUniversity.IntegrationTests.Controllers.University.Grades;
@@ -17,6 +19,8 @@ public class GradesControllerTestsAdminCrudControllersTest :
     public override string DeleteRoute => $"api/grades/{DefaultId}";
 
     public override int DefaultId => 1;
+
+    public override string GetPageFilter => "name=testfilter";
 
     public override void SetUpService()
     {
@@ -51,5 +55,11 @@ public class GradesControllerTestsAdminCrudControllersTest :
     protected override GradeCreateDto GetValidUpdateDto()
     {
         return new("100", 100);
+    }
+
+    protected override bool AssertThatFilterWasApplied(IFilter<Grade> filter)
+    {
+        return filter is NameFilter<Grade> nameFilter && nameFilter.Name == "testfilter";
+
     }
 }

--- a/IntegrationTests/Controllers/University/GroupsControllerTests.cs
+++ b/IntegrationTests/Controllers/University/GroupsControllerTests.cs
@@ -1,5 +1,6 @@
 ﻿using EUniversity.Core.Dtos.University;
 using EUniversity.Core.Dtos.Users;
+using EUniversity.Core.Filters;
 using EUniversity.Core.Models.University;
 using EUniversity.Core.Services.University;
 
@@ -22,6 +23,8 @@ public class GroupsControllerTests :
     public override string DeleteRoute => $"api/groups/{DefaultId}";
 
     public override int DefaultId => 1;
+
+    public override string GetPageFilter => "name=testfilter";
 
     protected override void AssertThatViewDtosAreEqual(GroupViewDto expected, GroupViewDto actual)
     {
@@ -75,5 +78,10 @@ public class GroupsControllerTests :
     protected override GroupCreateDto GetValidUpdateDto()
     {
         return new("Group2", 5, null);
+    }
+
+    protected override bool AssertThatFilterWasApplied(IFilter<Group> filter)
+    {
+        return filter is NameFilter<Group> nameFilter && nameFilter.Name == "testfilter";
     }
 }


### PR DESCRIPTION
This pull request introduces an optional `name` filter for specific GET endpoints. The primary goal of this enhancement is to empower frontend applications to implement advanced search functionalities and dropdown auto-completion.

## Changes Made
- Added a new optional query parameter `name` to the specified GET endpoints.
- Implemented the `NameFilter` class, which inherits from `IFilter`, to enable searching for entities based on their names.

## Affected Endpoints
The following GET endpoints have been updated to accept the optional `name` query parameter for filtering entities by name:
- `GET /api/classrooms`: Filters classrooms by name.
- `GET /api/courses`: Filters courses by name.
- `GET /api/groups`: Filters groups by name.
- `GET /api/grades`: Filters grades by name.

## Usage
This enhancement empowers frontend applications to implement advanced search and auto-completion features. Users can now search for specific entities by name using dropdowns (select elements). If the `name` parameter is not provided, the endpoints will return the complete list of entities.

## Testing
Unit tests were added for the `NameFilter` class to ensure its functionality. `CrudControllersTest` was modified to check whether HTTP GET page method use filters.