### PR TITLE
Add a `SemesterId` Foreign Key to `Course`

### DIFF
--- a/Core/Dtos/University/CourseCreateDto.cs
+++ b/Core/Dtos/University/CourseCreateDto.cs
@@ -3,4 +3,4 @@
 namespace EUniversity.Core.Dtos.University;
 
 [ValidateNever] // Remove data annotations validation
-public record CourseCreateDto(string Name, string? Description);
+public record CourseCreateDto(string Name, string? Description, int? SemesterId);

--- a/Core/Dtos/University/CoursePreviewDto.cs
+++ b/Core/Dtos/University/CoursePreviewDto.cs
@@ -1,3 +1,3 @@
 ﻿namespace EUniversity.Core.Dtos.University;
 
-public record CoursePreviewDto(int Id, string Name);
+public record CoursePreviewDto(int Id, string Name, SemesterMinimalViewDto? Semester);

--- a/Core/Dtos/University/CourseViewDto.cs
+++ b/Core/Dtos/University/CourseViewDto.cs
@@ -1,3 +1,3 @@
 ﻿namespace EUniversity.Core.Dtos.University;
 
-public record CourseViewDto(int Id, string Name, string? Description);
+public record CourseViewDto(int Id, string Name, string? Description, SemesterPreviewDto? Semester);

--- a/Core/Dtos/University/SemesterMinimalViewDto.cs
+++ b/Core/Dtos/University/SemesterMinimalViewDto.cs
@@ -1,0 +1,3 @@
+﻿namespace EUniversity.Core.Dtos.University;
+
+public record SemesterMinimalViewDto(int Id, string Name);

--- a/Core/Mapping/MappingGlobalSettings.cs
+++ b/Core/Mapping/MappingGlobalSettings.cs
@@ -1,4 +1,6 @@
-﻿using Mapster;
+﻿using EUniversity.Core.Dtos.University;
+using Mapster;
+using EUniversity.Core.Models.University;
 
 namespace EUniversity.Core.Mapping;
 
@@ -6,6 +8,11 @@ public static class MappingGlobalSettings
 {
     public static void Apply()
     {
+        TypeAdapterConfig<Group, GroupPreviewDto>.NewConfig()
+            .IgnoreIf((src, dest) => src.TeacherId == null, dest => dest.Teacher!);
+        TypeAdapterConfig<Course, CoursePreviewDto>.NewConfig()
+            .IgnoreIf((src, dest) => src.SemesterId == null, dest => dest.Semester!);
+
         TypeAdapterConfig.GlobalSettings.Default
             .AddDestinationTransform((string? dest) => string.IsNullOrWhiteSpace(dest) ? null : dest);
     }

--- a/Core/Models/University/Course.cs
+++ b/Core/Models/University/Course.cs
@@ -1,4 +1,6 @@
-﻿namespace EUniversity.Core.Models.University;
+﻿using System.ComponentModel.DataAnnotations.Schema;
+
+namespace EUniversity.Core.Models.University;
 
 /// <summary>
 /// Represents a course entity.
@@ -11,6 +13,11 @@ public class Course : IEntity<int>, IHasName
     [Key]
     public int Id { get; set; }
     /// <summary>
+    /// Foreign key of the semester associated with this course(may be null).
+    /// </summary>
+    [ForeignKey(nameof(Semester))]
+    public int? SemesterId { get; set; }
+    /// <summary>
     /// Name of the course.
     /// </summary>
     [StringLength(MaxNameLength)]
@@ -20,4 +27,9 @@ public class Course : IEntity<int>, IHasName
     /// </summary>
     [StringLength(MaxDescriptionLength)]
     public string? Description { get; set; }
+
+    /// <summary>
+    /// Navigation property of the semester associated with this course(may be null).
+    /// </summary>
+    public Semester? Semester { get; set; }
 }

--- a/Core/Models/University/Semester.cs
+++ b/Core/Models/University/Semester.cs
@@ -31,4 +31,8 @@ public class Semester : IEntity<int>, IHasName
     /// Navigation property to the student enrollments of this semester.
     /// </summary>
     public ICollection<StudentSemester> StudentEnrollments { get; set; } = null!;
+    /// <summary>
+    /// Navigation property to the courses of this semester.
+    /// </summary>
+    public ICollection<Course> Courses { get; set; } = null!;
 }

--- a/Core/Validation/University/CourseCreateDtoValidator.cs
+++ b/Core/Validation/University/CourseCreateDtoValidator.cs
@@ -23,5 +23,12 @@ public class CourseCreateDtoValidator : AbstractValidator<CourseCreateDto>
             .MaximumLength(Course.MaxDescriptionLength)
             .WithErrorCode(ValidationErrorCodes.PropertyTooLarge)
             .WithMessage($"Course description cannot exceed {Course.MaxNameLength} characters");
+
+        RuleFor(x => x.SemesterId)
+            .MustAsync(async (id, _) =>
+                await existenceChecker.ExistsAsync<Semester, int>(id!.Value))
+            .When(x => x.SemesterId != null)
+            .WithErrorCode(ValidationErrorCodes.InvalidForeignKey)
+            .WithMessage("Semester does not exist");
     }
 }

--- a/Core/Validation/University/CourseCreateDtoValidator.cs
+++ b/Core/Validation/University/CourseCreateDtoValidator.cs
@@ -1,12 +1,13 @@
 ﻿using EUniversity.Core.Dtos.University;
 using EUniversity.Core.Models.University;
+using EUniversity.Core.Services;
 using FluentValidation;
 
 namespace EUniversity.Core.Validation.University;
 
 public class CourseCreateDtoValidator : AbstractValidator<CourseCreateDto>
 {
-    public CourseCreateDtoValidator()
+    public CourseCreateDtoValidator(IEntityExistenceChecker existenceChecker)
     {
         RuleFor(x => x.Name)
             .NotEmpty()

--- a/EUniversity.Tests/Validation/University/CourseCreateDtoValidatorTests.cs
+++ b/EUniversity.Tests/Validation/University/CourseCreateDtoValidatorTests.cs
@@ -1,45 +1,57 @@
 ﻿using EUniversity.Core.Dtos.University;
 using EUniversity.Core.Models.University;
+using EUniversity.Core.Services;
 using EUniversity.Core.Validation;
 using EUniversity.Core.Validation.University;
 using FluentValidation.TestHelper;
 
 namespace EUniversity.Tests.Validation.University;
 
-public class CourseCreateDtoValidatorTests
+public class CourseCreateDtoValidatorTests : UsersValidatorTests
 {
     private CourseCreateDtoValidator _validator;
 
     private const string DefaultName = "Course";
     private const string DefaultDescription = "Course description. . .";
+    private const int TestSemesterId = 4;
+    private const int NonExistentSemesterId = 2;
 
     [OneTimeSetUp]
     public void OneTimeSetUp()
     {
-        _validator = new();
+        // Mock validator dependencies
+        var existenceChecker = Substitute.For<IEntityExistenceChecker>();
+        existenceChecker
+            .ExistsAsync<Semester, int>(Arg.Any<int>())
+            .Returns(false);
+        existenceChecker
+            .ExistsAsync<Semester, int>(TestSemesterId)
+            .Returns(true);
+
+        _validator = new(existenceChecker);
     }
 
     [Test]
-    public void Dto_Valid_Succeeds()
+    public async Task Dto_Valid_Succeeds()
     {
         // Arrange
-        CourseCreateDto dto = new(DefaultName, DefaultDescription);
+        CourseCreateDto dto = new(DefaultName, DefaultDescription, TestSemesterId);
 
         // Act
-        var result = _validator.TestValidate(dto);
+        var result = await _validator.TestValidateAsync(dto);
 
         // Assert
         result.ShouldNotHaveAnyValidationErrors();
     }
 
     [Test]
-    public void Name_TooLarge_FailsWithPropertyTooLargeError()
+    public async Task Name_TooLarge_FailsWithPropertyTooLargeError()
     {
         // Arrange
-        CourseCreateDto dto = new(new string('0', Course.MaxNameLength + 1), DefaultDescription);
+        CourseCreateDto dto = new(new string('0', Course.MaxNameLength + 1), DefaultDescription,TestSemesterId);
 
         // Act
-        var result = _validator.TestValidate(dto);
+        var result = await _validator.TestValidateAsync(dto);
 
         // Assert
         result.ShouldHaveValidationErrorFor(dto => dto.Name)
@@ -47,13 +59,13 @@ public class CourseCreateDtoValidatorTests
     }
 
     [Test]
-    public void Name_Empty_FailsWithPropertyRequiredError()
+    public async Task Name_Empty_FailsWithPropertyRequiredError()
     {
         // Arrange
-        CourseCreateDto dto = new(string.Empty, DefaultDescription);
+        CourseCreateDto dto = new(string.Empty, DefaultDescription, TestSemesterId);
 
         // Act
-        var result = _validator.TestValidate(dto);
+        var result = await _validator.TestValidateAsync(dto);
 
         // Assert
         result.ShouldHaveValidationErrorFor(dto => dto.Name)
@@ -63,29 +75,56 @@ public class CourseCreateDtoValidatorTests
     [Test]
     [TestCase(null)]
     [TestCase("")]
-    public void Description_NullOrEmpty_Succeeds(string? description)
+    public async Task Description_NullOrEmpty_Succeeds(string? description)
     {
         // Arrange
-        CourseCreateDto dto = new(DefaultName, description);
+        CourseCreateDto dto = new(DefaultName, description, TestSemesterId);
 
         // Act
-        var result = _validator.TestValidate(dto);
+        var result = await _validator.TestValidateAsync(dto);
 
         // Assert
         result.ShouldNotHaveAnyValidationErrors();
     }
 
     [Test]
-    public void Description_TooLarge_FailsWithPropertyTooLargeError()
+    public async Task Description_TooLarge_FailsWithPropertyTooLargeError()
     {
         // Arrange
-        CourseCreateDto dto = new(DefaultName, new string('0', Course.MaxDescriptionLength + 1));
+        CourseCreateDto dto = new(DefaultName, new string('0', Course.MaxDescriptionLength + 1), TestSemesterId);
 
         // Act
-        var result = _validator.TestValidate(dto);
+        var result = await _validator.TestValidateAsync(dto);
 
         // Assert
         result.ShouldHaveValidationErrorFor(dto => dto.Description)
             .WithErrorCode(ValidationErrorCodes.PropertyTooLarge);
+    }
+
+    [Test]
+    public async Task SemesterId_Null_Succeeds()
+    {
+        // Arrange
+        CourseCreateDto dto = new(DefaultName, DefaultDescription, null);
+
+        // Act
+        var result = await _validator.TestValidateAsync(dto);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(dto => dto.SemesterId);
+    }
+
+    [Test]
+    public async Task SemesterId_SemesterDoesNotExist_FailsWithInvalidForeignKeyError()
+    {
+        // Arrange
+        CourseCreateDto dto = new(DefaultName, DefaultDescription, NonExistentSemesterId);
+
+        // Act
+        var result = await _validator.TestValidateAsync(dto);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(dto => dto.SemesterId)
+            .WithErrorCode(ValidationErrorCodes.InvalidForeignKey);
     }
 }

--- a/EUniversity.Tests/Validation/University/CourseCreateDtoValidatorTests.cs
+++ b/EUniversity.Tests/Validation/University/CourseCreateDtoValidatorTests.cs
@@ -111,7 +111,7 @@ public class CourseCreateDtoValidatorTests : UsersValidatorTests
         var result = await _validator.TestValidateAsync(dto);
 
         // Assert
-        result.ShouldHaveValidationErrorFor(dto => dto.SemesterId);
+        result.ShouldNotHaveValidationErrorFor(dto => dto.SemesterId);
     }
 
     [Test]

--- a/EUniversity/Extensions/WebApplicationExtensions.cs
+++ b/EUniversity/Extensions/WebApplicationExtensions.cs
@@ -74,10 +74,10 @@ public static class WebApplicationExtensions
 
         testDataService.CreateFakeUsersAsync().Wait();
         testDataService.CreateFakeClassroomsAsync().Wait();
+        testDataService.CreateFakeSemestersAsync().Wait();
         testDataService.CreateFakeGradesAsync().Wait();
         testDataService.CreateFakeCoursesAsync().Wait();
         testDataService.CreateFakeGroupsAsync().Wait();
-        testDataService.CreateFakeSemestersAsync().Wait();
 
         return app;
     }

--- a/Infrastructure/Migrations/20231121074916_AddSemesterForeignKeyToCourse.Designer.cs
+++ b/Infrastructure/Migrations/20231121074916_AddSemesterForeignKeyToCourse.Designer.cs
@@ -4,6 +4,7 @@ using EUniversity.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EUniversity.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20231121074916_AddSemesterForeignKeyToCourse")]
+    partial class AddSemesterForeignKeyToCourse
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Infrastructure/Migrations/20231121074916_AddSemesterForeignKeyToCourse.cs
+++ b/Infrastructure/Migrations/20231121074916_AddSemesterForeignKeyToCourse.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EUniversity.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSemesterForeignKeyToCourse : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "SemesterId",
+                table: "Courses",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Courses_SemesterId",
+                table: "Courses",
+                column: "SemesterId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Courses_Semesters_SemesterId",
+                table: "Courses",
+                column: "SemesterId",
+                principalTable: "Semesters",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Courses_Semesters_SemesterId",
+                table: "Courses");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Courses_SemesterId",
+                table: "Courses");
+
+            migrationBuilder.DropColumn(
+                name: "SemesterId",
+                table: "Courses");
+        }
+    }
+}

--- a/Infrastructure/Services/Test/TestDataService.cs
+++ b/Infrastructure/Services/Test/TestDataService.cs
@@ -161,9 +161,16 @@ public class TestDataService
     /// <param name="count">Number of courses to be created.</param>
     public async Task CreateFakeCoursesAsync(int count = 50)
     {
+        // IDs of semesters
+        var teachersIds = await _dbContext.Semesters
+            .Select(c => c.Id)
+            .ToArrayAsync();
+
         var coursesFaker = new Faker<Course>()
             .RuleFor(c => c.Name, f => f.Company.CatchPhrase())
-            .RuleFor(c => c.Description, f => f.Lorem.Sentences(f.Random.Number(1, 3), " "));
+            .RuleFor(c => c.Description, f => f.Lorem.Sentences(f.Random.Number(1, 3), " "))
+            // Random teacher ID(90% probabilty) or null
+            .RuleFor(c => c.SemesterId, f => f.Random.Bool(0.9f) ? f.Random.CollectionItem(teachersIds) : null);
 
         await CreateFakeEntitiesAsync(coursesFaker, count);
     }
@@ -278,5 +285,4 @@ public class TestDataService
             await CreateFakeEntitiesAsync(studentSemesterFaker, studentsCount, false);
         }
     }
-
 }

--- a/Infrastructure/Services/University/CoursesService.cs
+++ b/Infrastructure/Services/University/CoursesService.cs
@@ -9,6 +9,16 @@ public class CoursesService :
     BaseCrudService<Course, int, CoursePreviewDto, CourseViewDto, CourseCreateDto, CourseCreateDto>,
     ICoursesService
 {
+    protected override IQueryable<Course> GetByIdQuery => 
+        Entities
+        .Include(e => e.Semester)
+        .AsNoTracking();
+
+    protected override IQueryable<Course> GetPageQuery =>
+        Entities
+        .Include(e => e.Semester)
+        .AsNoTracking();
+
     public CoursesService(ApplicationDbContext dbContext) : base(dbContext)
     {
     }

--- a/IntegrationTests/Controllers/University/CoursesControllerTests.cs
+++ b/IntegrationTests/Controllers/University/CoursesControllerTests.cs
@@ -1,6 +1,7 @@
 ﻿using EUniversity.Core.Dtos.University;
 using EUniversity.Core.Filters;
 using EUniversity.Core.Models.University;
+using EUniversity.Core.Services.University;
 
 namespace EUniversity.IntegrationTests.Controllers.University;
 
@@ -24,6 +25,8 @@ public class CoursesControllerTests :
     public override void SetUpService()
     {
         ServiceMock = WebApplicationFactory.CoursesServiceMock;
+        Assert.That(ServiceMock, Is.InstanceOf<ICoursesService>());
+        SetUpValidationMocks();
     }
 
     protected override bool AssertThatFilterWasApplied(IFilter<Course> filter)
@@ -33,31 +36,34 @@ public class CoursesControllerTests :
 
     protected override CourseCreateDto GetInvalidCreateDto()
     {
-        return new(string.Empty, null);
+        return new(string.Empty, null, null);
     }
 
     protected override CourseCreateDto GetInvalidUpdateDto()
     {
-        return new(string.Empty, null);
+        return GetInvalidCreateDto();
     }
 
     protected override CourseViewDto GetTestDetailsDto()
     {
-        return new(DefaultId, "Test", null);
+        SemesterPreviewDto semester = new(4, "Test semester",
+            DateTimeOffset.MinValue, DateTimeOffset.MaxValue);
+        return new(DefaultId, "Test", null, semester);
     }
 
     protected override CoursePreviewDto GetTestPreviewDto()
     {
-        return new(DefaultId, "Test");
+        SemesterMinimalViewDto semester = new(4, "Test semester");
+        return new(DefaultId, "Test", semester);
     }
 
     protected override CourseCreateDto GetValidCreateDto()
     {
-        return new("Test", "test");
+        return new("Test", "test", null);
     }
 
     protected override CourseCreateDto GetValidUpdateDto()
     {
-        return new("Test", "test2");
+        return new("Test", "test2", 5);
     }
 }

--- a/IntegrationTests/Controllers/University/GroupsControllerTests.cs
+++ b/IntegrationTests/Controllers/University/GroupsControllerTests.cs
@@ -10,7 +10,7 @@ public class GroupsControllerTests :
     AdminCrudControllersTest<Group, int, GroupPreviewDto, GroupViewDto, GroupCreateDto, GroupCreateDto>
 {
     public readonly TeacherPreviewDto TeacherPreviewDto = new(Guid.NewGuid().ToString(), "test-teacher", "Teacher1", "Teacher2", null);
-    public readonly CoursePreviewDto CoursePreviewDto = new(5, "Some Course");
+    public readonly CoursePreviewDto CoursePreviewDto = new(5, "Some Course", null);
 
     public override string GetPageRoute => "api/groups";
 

--- a/IntegrationTests/Services/University/CoursesServiceTests.cs
+++ b/IntegrationTests/Services/University/CoursesServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿using EUniversity.Core.Dtos.University;
 using EUniversity.Core.Models.University;
+using EUniversity.Core.Policy;
 using EUniversity.Core.Services.University;
 
 namespace EUniversity.IntegrationTests.Services.University;
@@ -7,12 +8,16 @@ namespace EUniversity.IntegrationTests.Services.University;
 public class CoursesServiceTests :
     CrudServicesTest<ICoursesService, Course, int, CoursePreviewDto, CourseViewDto, CourseCreateDto, CourseCreateDto>
 {
-    public static Course CreateTestCourse()
+    private Semester _testSemester;
+
+    public static Course CreateTestCourse(Semester? testSemester = null)
     {
         return new()
         {
             Name = "Chemistry",
-            Description = "Walter's White cooking course"
+            Description = "Walter's White cooking course",
+            Semester = testSemester,
+            SemesterId = testSemester?.Id
         };
     }
 
@@ -23,6 +28,7 @@ public class CoursesServiceTests :
         {
             Assert.That(actualEntity.Name, Is.EqualTo(updateDto.Name));
             Assert.That(actualEntity.Description, Is.EqualTo(updateDto.Description));
+            Assert.That(actualEntity.SemesterId, Is.EqualTo(updateDto.SemesterId));
         });
     }
 
@@ -41,12 +47,20 @@ public class CoursesServiceTests :
     /// <inheritdoc />
     protected override CourseCreateDto GetValidCreateDto()
     {
-        return new("Physics", "g/(pi^2) = 1");
+        return new("Physics", "g/(pi^2) = 1", _testSemester.Id);
     }
 
     /// <inheritdoc />
     protected override CourseCreateDto GetValidUpdateDto()
     {
-        return new("Math", "Not to be confused with meth");
+        return new("Math", "Not to be confused with meth", null);
+    }
+
+    [SetUp]
+    public async Task SetUpDependencies()
+    {
+        _testSemester = SemestersServiceTests.GetTestSemester();
+        DbContext.Add(_testSemester);
+        await DbContext.SaveChangesAsync();
     }
 }


### PR DESCRIPTION
This pull request adds a `SemesterId` foregign key to the `Course` entity.

### Changes made
1. Configured a one-to-many relationship between a course and a semester(it should be optional).
2. Changed existing DTOs and validation with unit tests, services and endpoints to accommodate the previous change.
3. Configured mapping setting to ignore null values when mapping from `Course` and `Group`.
4. Configured test data generation for updated courses.