### PR TITLE
Make Separate Get Methods for Subentities

### DIFF
--- a/Core/Dtos/University/StudentGroupViewDto.cs
+++ b/Core/Dtos/University/StudentGroupViewDto.cs
@@ -1,0 +1,5 @@
+﻿using EUniversity.Core.Dtos.Users;
+
+namespace EUniversity.Core.Dtos.University;
+
+public record StudentGroupViewDto(StudentPreviewDto Student, DateTimeOffset EnrollmentDate);

--- a/Core/Models/University/StudentGroup.cs
+++ b/Core/Models/University/StudentGroup.cs
@@ -12,6 +12,11 @@ public class StudentGroup : IEntity<int>
     public int Id { get; set; }
 
     /// <summary>
+    /// Date when student was added to the group.
+    /// </summary>
+    public DateTimeOffset EnrollmentDate { get; set; }
+
+    /// <summary>
     /// Foreign key of the associated student.
     /// </summary>
     [ForeignKey(nameof(Student))]

--- a/Core/Services/IAssigningService.cs
+++ b/Core/Services/IAssigningService.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq.Expressions;
+﻿using EUniversity.Core.Filters;
+using EUniversity.Core.Pagination;
+using System.Linq.Expressions;
 
 namespace EUniversity.Core.Services;
 
@@ -24,6 +26,18 @@ public interface IAssigningService<TAssigningEntity, TId1, TId2>
     /// an instance of assigning entity in the database.
     /// </returns>
     public Expression<Func<TAssigningEntity, bool>> AssigningEntityPredicate(TId1 id1, TId2 id2);
+
+    /// <summary>
+    /// Retrieves a page with assigning entities DTOs asynchronously.
+    /// </summary>
+    /// <param name="properties"><see cref="PaginationProperties"/> object specifying pagination parameters.</param>
+    /// <param name="filter">An optional filter to apply.</param>
+    /// <returns>
+    /// A task that represents the asynchronous operation, containing 
+    /// the page with assigning entities DTOs asynchronously.
+    /// </returns>
+    /// <typeparam name="TViewDto">A type of the DTO to which entities will be mapped.</typeparam>
+    public Task<Page<TViewDto>> GetAssigningEntitiesPageAsync<TViewDto>(PaginationProperties properties, IFilter<TAssigningEntity>? filter = null);
 
     /// <summary>
     /// Adds the first entity to the second based on their IDs.

--- a/Core/Services/IAssigningService.cs
+++ b/Core/Services/IAssigningService.cs
@@ -30,6 +30,7 @@ public interface IAssigningService<TAssigningEntity, TId1, TId2>
     /// <summary>
     /// Retrieves a page with assigning entities DTOs asynchronously.
     /// </summary>
+    /// <param name="id1">ID of the entity for which assigned entities should be returned.</param>
     /// <param name="properties"><see cref="PaginationProperties"/> object specifying pagination parameters.</param>
     /// <param name="filter">An optional filter to apply.</param>
     /// <returns>
@@ -37,7 +38,7 @@ public interface IAssigningService<TAssigningEntity, TId1, TId2>
     /// the page with assigning entities DTOs asynchronously.
     /// </returns>
     /// <typeparam name="TViewDto">A type of the DTO to which entities will be mapped.</typeparam>
-    public Task<Page<TViewDto>> GetAssigningEntitiesPageAsync<TViewDto>(PaginationProperties properties, IFilter<TAssigningEntity>? filter = null);
+    public Task<Page<TViewDto>> GetAssigningEntitiesPageAsync<TViewDto>(TId1 id1, PaginationProperties properties, IFilter<TAssigningEntity>? filter = null);
 
     /// <summary>
     /// Adds the first entity to the second based on their IDs.

--- a/Infrastructure/Migrations/20231126143434_AddEnrollmentDateToStudentGroup.Designer.cs
+++ b/Infrastructure/Migrations/20231126143434_AddEnrollmentDateToStudentGroup.Designer.cs
@@ -4,6 +4,7 @@ using EUniversity.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EUniversity.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20231126143434_AddEnrollmentDateToStudentGroup")]
+    partial class AddEnrollmentDateToStudentGroup
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Infrastructure/Migrations/20231126143434_AddEnrollmentDateToStudentGroup.cs
+++ b/Infrastructure/Migrations/20231126143434_AddEnrollmentDateToStudentGroup.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EUniversity.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEnrollmentDateToStudentGroup : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "EnrollmentDate",
+                table: "StudentGroups",
+                type: "datetimeoffset",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EnrollmentDate",
+                table: "StudentGroups");
+        }
+    }
+}

--- a/Infrastructure/Services/AssigningService.cs
+++ b/Infrastructure/Services/AssigningService.cs
@@ -1,4 +1,6 @@
-﻿using EUniversity.Core.Services;
+﻿using EUniversity.Core.Filters;
+using EUniversity.Core.Pagination;
+using EUniversity.Core.Services;
 using EUniversity.Infrastructure.Data;
 using System.Linq.Expressions;
 
@@ -46,6 +48,12 @@ public abstract class AssigningService<TAssigningEntity, TId1, TId2> : IAssignin
     /// an instance of assigning entity in the database.
     /// </returns>
     public abstract Expression<Func<TAssigningEntity, bool>> AssigningEntityPredicate(TId1 id1, TId2 id2);
+
+    /// <inheritdoc />
+    public virtual Task<Page<TViewDto>> GetAssigningEntitiesPageAsync<TViewDto>(PaginationProperties properties, IFilter<TAssigningEntity>? filter = null)
+    {
+        throw new NotImplementedException();
+    }
 
     /// <inheritdoc />
     public virtual async Task<bool> AssignAsync(TId1 entity1Id, TId2 entity2Id)

--- a/Infrastructure/Services/AssigningService.cs
+++ b/Infrastructure/Services/AssigningService.cs
@@ -2,6 +2,7 @@
 using EUniversity.Core.Pagination;
 using EUniversity.Core.Services;
 using EUniversity.Infrastructure.Data;
+using EUniversity.Infrastructure.Pagination;
 using System.Linq.Expressions;
 
 namespace EUniversity.Infrastructure.Services;
@@ -20,6 +21,12 @@ public abstract class AssigningService<TAssigningEntity, TId1, TId2> : IAssignin
 {
     protected ApplicationDbContext DbContext { get; init; }
     protected DbSet<TAssigningEntity> AssigningEntities => DbContext.Set<TAssigningEntity>();
+
+    /// <summary>
+    /// When implemented, gets a query used for obtaining a page with assigning entities.
+    /// </summary>    
+    /// <param name="id1">ID of the entity for which assigned entities should be returned.</param>
+    protected abstract IQueryable<TAssigningEntity> GetPageQuery(TId1 id1);
 
     public AssigningService(ApplicationDbContext dbContext)
     {
@@ -50,9 +57,12 @@ public abstract class AssigningService<TAssigningEntity, TId1, TId2> : IAssignin
     public abstract Expression<Func<TAssigningEntity, bool>> AssigningEntityPredicate(TId1 id1, TId2 id2);
 
     /// <inheritdoc />
-    public virtual Task<Page<TViewDto>> GetAssigningEntitiesPageAsync<TViewDto>(PaginationProperties properties, IFilter<TAssigningEntity>? filter = null)
+    public virtual async Task<Page<TViewDto>> GetAssigningEntitiesPageAsync<TViewDto>(TId1 id1, PaginationProperties properties, IFilter<TAssigningEntity>? filter = null)
     {
-        throw new NotImplementedException();
+        var query = GetPageQuery(id1);
+        if (filter != null) query = filter.Apply(query);
+
+        return await query.ToPageAsync<TAssigningEntity, TViewDto>(properties);
     }
 
     /// <inheritdoc />

--- a/Infrastructure/Services/Test/TestDataService.cs
+++ b/Infrastructure/Services/Test/TestDataService.cs
@@ -227,7 +227,8 @@ public class TestDataService
             int i = 0;
             var studentGroupFaker = new Faker<StudentGroup>()
                 .RuleFor(s => s.GroupId, _ => groupId)
-                .RuleFor(s => s.StudentId, _ => shuffledStudentsIds[i++]);
+                .RuleFor(s => s.StudentId, _ => shuffledStudentsIds[i++])
+                .RuleFor(s => s.EnrollmentDate, f => f.Date.Recent(180));
             int studentsCount = faker.Random.Int(minStudentsInGroup, maxStudentsInGroup);
             await CreateFakeEntitiesAsync(studentGroupFaker, studentsCount, false);
         }

--- a/Infrastructure/Services/University/StudentGroupsService.cs
+++ b/Infrastructure/Services/University/StudentGroupsService.cs
@@ -26,7 +26,8 @@ public class StudentGroupsService :
         return new()
         {
             GroupId = groupId,
-            StudentId = studentId
+            StudentId = studentId,
+            EnrollmentDate = DateTimeOffset.Now
         };
     }
 }

--- a/Infrastructure/Services/University/StudentGroupsService.cs
+++ b/Infrastructure/Services/University/StudentGroupsService.cs
@@ -30,4 +30,10 @@ public class StudentGroupsService :
             EnrollmentDate = DateTimeOffset.Now
         };
     }
+
+    /// <inheritdoc />
+    protected override IQueryable<StudentGroup> GetPageQuery(int id1)
+    {
+        return AssigningEntities.AsNoTracking().Where(sg => sg.GroupId == id1);
+    }
 }

--- a/Infrastructure/Services/University/StudentSemestersService.cs
+++ b/Infrastructure/Services/University/StudentSemestersService.cs
@@ -26,4 +26,10 @@ public class StudentSemestersService :
             EnrollmentDate = DateTimeOffset.Now
         };
     }
+
+    /// <inheritdoc />
+    protected override IQueryable<StudentSemester> GetPageQuery(int id1)
+    {
+        return AssigningEntities.AsNoTracking().Where(sm => sm.SemesterId == id1);
+    }
 }

--- a/IntegrationTests/Controllers/AssigningEndpointsTests.cs
+++ b/IntegrationTests/Controllers/AssigningEndpointsTests.cs
@@ -102,6 +102,25 @@ public abstract class AssigningEndpointsTests<TService, TAssigningEntity, TEntit
     protected abstract object GetAssignDto();
 
     [Test]
+    public virtual async Task GetPage_Entity1DoesNotExist_Returns404NotFound()
+    {
+        // Arrange
+        using var client = CreateStudentClient();
+        ServiceMock
+            .GetAssigningEntitiesPageAsync<TViewDto>(Arg.Any<TId1>(), Arg.Any<PaginationProperties>(), Arg.Any<IFilter<TAssigningEntity>>())
+            .Throws<InvalidOperationException>();
+        WebApplicationFactory.ExistenceCheckerMock
+            .ExistsAsync<TEntity1, TId1>(TestId1)
+            .Returns(false);
+
+        // Act
+        var result = await client.GetAsync(GetPageRoute);
+
+        // Assert
+        Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+    }
+
+    [Test]
     public virtual async Task GetPage_NoFilter_SucceedsAndReturnsValidDto()
     {
         // Arrange

--- a/IntegrationTests/Controllers/AssigningEndpointsTests.cs
+++ b/IntegrationTests/Controllers/AssigningEndpointsTests.cs
@@ -1,6 +1,9 @@
 ﻿using EUniversity.Core.Dtos.University;
+using EUniversity.Core.Filters;
 using EUniversity.Core.Models;
+using EUniversity.Core.Pagination;
 using EUniversity.Core.Services;
+using IdentityModel;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using System.Net;
@@ -17,7 +20,8 @@ namespace EUniversity.IntegrationTests.Controllers;
 /// <typeparam name="TId1">A type of the ID of the first entity.</typeparam>
 /// <typeparam name="TEntity2">A type of the second entity.</typeparam>
 /// <typeparam name="TId2">A type of the ID of the second entity.</typeparam>
-public abstract class AssigningEndpointsTests<TService, TAssigningEntity, TEntity1, TId1, TEntity2, TId2> : ControllersTest
+/// <typeparam name="TViewDto">A type of a view DTO.</typeparam>
+public abstract class AssigningEndpointsTests<TService, TAssigningEntity, TEntity1, TId1, TEntity2, TId2, TViewDto> : ControllersTest
     where TService : class, IAssigningService<TAssigningEntity, TId1, TId2>
     where TAssigningEntity : class
     where TEntity1 : class, IEntity<TId1>
@@ -43,6 +47,28 @@ public abstract class AssigningEndpointsTests<TService, TAssigningEntity, TEntit
     }
 
     /// <summary>
+    /// When implemented, gets test <typeparamref name="TViewDto"/>.
+    /// </summary>
+    /// <returns>
+    /// Test <typeparamref name="TViewDto"/>.
+    /// </returns>
+    protected abstract TViewDto GetTestPreviewDto();
+
+    /// <summary>
+    /// Returns a test page with <typeparamref name="TViewDto"/>s. 
+    /// </summary>
+    /// <param name="properties">Pagination properties used for the page.</param>
+    /// <returns>
+    /// A test page with <typeparamref name="TViewDto"/>s. 
+    /// </returns>
+    protected virtual Page<TViewDto> GetTestPreviewDtos(PaginationProperties properties)
+    {
+        IEnumerable<TViewDto> testEnumerable =
+            Enumerable.Repeat(GetTestPreviewDto(), 10);
+        return new(testEnumerable, properties, 100);
+    }
+
+    /// <summary>
     /// Test ID of the first entity.
     /// </summary>
     public abstract TId1 TestId1 { get; }
@@ -51,6 +77,11 @@ public abstract class AssigningEndpointsTests<TService, TAssigningEntity, TEntit
     /// </summary>
     public abstract TId2 TestId2 { get; }
 
+    /// <summary>
+    /// Route used for getting a page of assigning entities.
+    /// E.g.: "api/entities/[TestId1]/subentities/".
+    /// </summary>
+    public abstract string GetPageRoute { get; }
     /// <summary>
     /// Route used for assigning an entity.
     /// E.g.: "api/entities/[TestId1]/subentities/".
@@ -69,6 +100,47 @@ public abstract class AssigningEndpointsTests<TService, TAssigningEntity, TEntit
     /// A DTO which is passed to the assigning route.
     /// </returns>
     protected abstract object GetAssignDto();
+
+    [Test]
+    public virtual async Task GetPage_NoFilter_SucceedsAndReturnsValidDto()
+    {
+        // Arrange
+        using var client = CreateStudentClient();
+        const int page = 2, pageSize = 25;
+        ServiceMock
+            .GetAssigningEntitiesPageAsync<TViewDto>(Arg.Any<TId1>(), Arg.Any<PaginationProperties>(), Arg.Any<IFilter<TAssigningEntity>>())
+            .Returns(x => Task.FromResult(GetTestPreviewDtos((PaginationProperties)x[0])));
+
+        // Act
+        var result = await client.GetAsync($"{GetPageRoute}?page={page}&pageSize={pageSize}");
+
+        // Assert
+        result.EnsureSuccessStatusCode();
+        var resultPage = await result.Content.ReadFromJsonAsync<Page<TViewDto>>();
+        Assert.That(resultPage, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(resultPage.PageNumber, Is.EqualTo(page));
+            Assert.That(resultPage.PageSize, Is.EqualTo(pageSize));
+            Assert.That(resultPage.Items.Count(), Is.LessThanOrEqualTo(pageSize));
+        });
+    }
+
+    [Test]
+    public virtual async Task GetPage_InvalidInput_Returns400BadRequest()
+    {
+        // Arrange
+        using var client = CreateStudentClient();
+        ServiceMock
+            .GetAssigningEntitiesPageAsync<TViewDto>(Arg.Any<TId1>(), Arg.Any<PaginationProperties>(), Arg.Any<IFilter<TAssigningEntity>>())
+            .Throws<InvalidOperationException>();
+
+        // Act
+        var result = await client.GetAsync($"{GetPageRoute}?page=-1");
+
+        // Assert
+        Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+    }
 
     [Test]
     public async Task Assign_UnauthenticatedUser_Returns401Unauthorized()

--- a/IntegrationTests/Controllers/AssigningEndpointsTests.cs
+++ b/IntegrationTests/Controllers/AssigningEndpointsTests.cs
@@ -109,7 +109,7 @@ public abstract class AssigningEndpointsTests<TService, TAssigningEntity, TEntit
         const int page = 2, pageSize = 25;
         ServiceMock
             .GetAssigningEntitiesPageAsync<TViewDto>(Arg.Any<TId1>(), Arg.Any<PaginationProperties>(), Arg.Any<IFilter<TAssigningEntity>>())
-            .Returns(x => Task.FromResult(GetTestPreviewDtos((PaginationProperties)x[0])));
+            .Returns(x => Task.FromResult(GetTestPreviewDtos((PaginationProperties)x[1])));
 
         // Act
         var result = await client.GetAsync($"{GetPageRoute}?page={page}&pageSize={pageSize}");

--- a/IntegrationTests/Controllers/University/StudentGroupsEndpointsTests.cs
+++ b/IntegrationTests/Controllers/University/StudentGroupsEndpointsTests.cs
@@ -1,4 +1,6 @@
 ﻿using EUniversity.Core.Dtos.University;
+using EUniversity.Core.Dtos.Users;
+using EUniversity.Core.Filters;
 using EUniversity.Core.Models;
 using EUniversity.Core.Models.University;
 using EUniversity.Core.Services.University;
@@ -6,11 +8,13 @@ using EUniversity.Core.Services.University;
 namespace EUniversity.IntegrationTests.Controllers.University;
 
 public class StudentGroupsEndpointsTests :
-    AssigningEndpointsTests<IStudentGroupsService, StudentGroup, Group, int, ApplicationUser, string>
+    AssigningEndpointsTests<IStudentGroupsService, StudentGroup, Group, int, ApplicationUser, string, StudentGroupViewDto>
 {
     public override int TestId1 => 5;
 
     public override string TestId2 => "test-user-id";
+
+    public override string GetPageRoute => $"api/groups/{TestId1}/students";
 
     public override string AssignRoute => $"api/groups/{TestId1}/students";
 
@@ -25,5 +29,11 @@ public class StudentGroupsEndpointsTests :
     protected override object GetAssignDto()
     {
         return new AssignStudentDto(TestId2);
+    }
+
+    protected override StudentGroupViewDto GetTestPreviewDto()
+    {
+        StudentPreviewDto student = new("test-id", "test-user", "Test", "User", null);
+        return new(student, DateTimeOffset.Now);
     }
 }

--- a/IntegrationTests/Controllers/University/StudentSemestersEndpointsTests.cs
+++ b/IntegrationTests/Controllers/University/StudentSemestersEndpointsTests.cs
@@ -1,4 +1,5 @@
 ﻿using EUniversity.Core.Dtos.University;
+using EUniversity.Core.Dtos.Users;
 using EUniversity.Core.Models;
 using EUniversity.Core.Models.University;
 using EUniversity.Core.Services.University;
@@ -6,7 +7,7 @@ using EUniversity.Core.Services.University;
 namespace EUniversity.IntegrationTests.Controllers.University;
 
 public class StudentSemestersEndpointsTests :
-    AssigningEndpointsTests<IStudentSemestersService, StudentSemester, Semester, int, ApplicationUser, string>
+    AssigningEndpointsTests<IStudentSemestersService, StudentSemester, Semester, int, ApplicationUser, string, StudentSemesterViewDto>
 {
     public override int TestId1 => 7;
 
@@ -16,6 +17,8 @@ public class StudentSemestersEndpointsTests :
 
     public override string UnassignRoute => $"api/semesters/{TestId1}/students/{TestId2}";
 
+    public override string GetPageRoute => $"api/semesters/{TestId1}/students";
+
     public override void SetUpService()
     {
         ServiceMock = WebApplicationFactory.StudentSemestersServiceMock;
@@ -24,5 +27,11 @@ public class StudentSemestersEndpointsTests :
     protected override object GetAssignDto()
     {
         return new AssignStudentDto(TestId2);
+    }
+
+    protected override StudentSemesterViewDto GetTestPreviewDto()
+    {
+        StudentPreviewDto student = new("test-id", "test-user", "Test", "User", null);
+        return new(student, DateTimeOffset.Now);
     }
 }

--- a/IntegrationTests/Services/AssigningServiceTests.cs
+++ b/IntegrationTests/Services/AssigningServiceTests.cs
@@ -94,6 +94,7 @@ public abstract class AssigningServiceTests<TService, TAssigningEntity, TAssigni
     public virtual async Task GetPage_AppliesFilter()
     {
         // Arrange
+        TId1 id1 = await GetIdOfExistingEntity1Async();
         var filter = Substitute.For<IFilter<TAssigningEntity>>();
         filter
             .Apply(Arg.Any<IQueryable<TAssigningEntity>>())
@@ -101,7 +102,7 @@ public abstract class AssigningServiceTests<TService, TAssigningEntity, TAssigni
         PaginationProperties properties = new(1, 20);
 
         // Act
-        await Service.GetAssigningEntitiesPageAsync<TViewDto>(properties, filter);
+        await Service.GetAssigningEntitiesPageAsync<TViewDto>(id1, properties, filter);
 
         // Assert
         filter.Received(1)
@@ -112,10 +113,11 @@ public abstract class AssigningServiceTests<TService, TAssigningEntity, TAssigni
     public virtual async Task GetPage_ReceivesPaginationProperties()
     {
         // Arrange
+        TId1 id1 = await GetIdOfExistingEntity1Async();
         PaginationProperties properties = new(3, PaginationProperties.MinPageSize);
 
         // Act
-        var result = await Service.GetAssigningEntitiesPageAsync<TViewDto>(properties);
+        var result = await Service.GetAssigningEntitiesPageAsync<TViewDto>(id1, properties);
 
         // Assert
         Assert.Multiple(() =>
@@ -144,7 +146,7 @@ public abstract class AssigningServiceTests<TService, TAssigningEntity, TAssigni
         PaginationProperties properties = new(1, 20);
 
         // Act
-        var result = await Service.GetAssigningEntitiesPageAsync<TViewDto>(properties, filter);
+        var result = await Service.GetAssigningEntitiesPageAsync<TViewDto>(id1, properties, filter);
 
         // Assert
         Assert.That(result.TotalItemsCount, Is.EqualTo(expectedCount));

--- a/IntegrationTests/Services/AssigningServiceTests.cs
+++ b/IntegrationTests/Services/AssigningServiceTests.cs
@@ -1,6 +1,10 @@
-﻿using EUniversity.Core.Services;
+﻿using EUniversity.Core.Filters;
+using EUniversity.Core.Models;
+using EUniversity.Core.Pagination;
+using EUniversity.Core.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
 
 namespace EUniversity.IntegrationTests.Services;
 
@@ -9,11 +13,14 @@ namespace EUniversity.IntegrationTests.Services;
 /// </summary>
 /// <typeparam name="TService">A type of the <typeparamref name="TService"/> service that is being tested.</typeparam>
 /// <typeparam name="TAssigningEntity">A type of entity that configures a many-to-many relationship.</typeparam>
+/// <typeparam name="TAssigningEntityId">A type of assigning entity ID.</typeparam>
+/// <typeparam name="TViewDto">A type of a view DTO.</typeparam>
 /// <typeparam name="TId1">A type of the ID of the first entity.</typeparam>
 /// <typeparam name="TId2">A type of the ID of the second entity.</typeparam>
-public abstract class AssigningServiceTests<TService, TAssigningEntity, TId1, TId2> : ServicesTest
+public abstract class AssigningServiceTests<TService, TAssigningEntity, TAssigningEntityId, TViewDto, TId1, TId2> : ServicesTest
     where TService : IAssigningService<TAssigningEntity, TId1, TId2>
-    where TAssigningEntity : class
+    where TAssigningEntity : class, IEntity<TAssigningEntityId>
+    where TAssigningEntityId : IEquatable<TAssigningEntityId>
     where TId1 : IEquatable<TId1>
     where TId2 : IEquatable<TId2>
 {
@@ -81,6 +88,66 @@ public abstract class AssigningServiceTests<TService, TAssigningEntity, TId1, TI
         DbContext.Add(entity);
         await DbContext.SaveChangesAsync();
         return entity;
+    }
+
+    [Test]
+    public virtual async Task GetPage_AppliesFilter()
+    {
+        // Arrange
+        var filter = Substitute.For<IFilter<TAssigningEntity>>();
+        filter
+            .Apply(Arg.Any<IQueryable<TAssigningEntity>>())
+            .Returns(x => x[0]);
+        PaginationProperties properties = new(1, 20);
+
+        // Act
+        await Service.GetAssigningEntitiesPageAsync<TViewDto>(properties, filter);
+
+        // Assert
+        filter.Received(1)
+            .Apply(Arg.Any<IQueryable<TAssigningEntity>>());
+    }
+
+    [Test]
+    public virtual async Task GetPage_ReceivesPaginationProperties()
+    {
+        // Arrange
+        PaginationProperties properties = new(3, PaginationProperties.MinPageSize);
+
+        // Act
+        var result = await Service.GetAssigningEntitiesPageAsync<TViewDto>(properties);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.PageNumber, Is.EqualTo(properties.Page));
+            Assert.That(result.PageSize, Is.EqualTo(properties.PageSize));
+        });
+    }
+
+    [Test]
+    public virtual async Task GetPage_ReturnsCorrectTotalItemsCount()
+    {
+        // Arrange
+        TId1 id1 = await GetIdOfExistingEntity1Async();
+        TId2 id2 = await GetIdOfExistingEntity2Async();
+        var testEntity = await CreateTestAssigningEntityAsync(id1, id2);
+        int expectedCount = 1;
+
+        var filter = Substitute.For<IFilter<TAssigningEntity>>();
+        filter.Apply(Arg.Any<IQueryable<TAssigningEntity>>())
+            .Returns(x =>
+            {
+                var query = (IQueryable<TAssigningEntity>)x[0];
+                return query.Where(e => e.Id.Equals(testEntity.Id));
+            });
+        PaginationProperties properties = new(1, 20);
+
+        // Act
+        var result = await Service.GetAssigningEntitiesPageAsync<TViewDto>(properties, filter);
+
+        // Assert
+        Assert.That(result.TotalItemsCount, Is.EqualTo(expectedCount));
     }
 
     [Test]

--- a/IntegrationTests/Services/University/StudentGroupsServiceTests.cs
+++ b/IntegrationTests/Services/University/StudentGroupsServiceTests.cs
@@ -1,11 +1,12 @@
-﻿using EUniversity.Core.Models.University;
+﻿using EUniversity.Core.Dtos.University;
+using EUniversity.Core.Models.University;
 using EUniversity.Core.Policy;
 using EUniversity.Core.Services.University;
 
 namespace EUniversity.IntegrationTests.Services.University;
 
 public class StudentGroupsServiceTests :
-    AssigningServiceTests<IStudentGroupsService, StudentGroup, int, string>
+    AssigningServiceTests<IStudentGroupsService, StudentGroup, int, StudentGroupViewDto, int, string>
 {
     protected override async Task<int> GetIdOfExistingEntity1Async()
     {

--- a/IntegrationTests/Services/University/StudentSemestersServiceTests.cs
+++ b/IntegrationTests/Services/University/StudentSemestersServiceTests.cs
@@ -1,11 +1,12 @@
-﻿using EUniversity.Core.Models.University;
+﻿using EUniversity.Core.Dtos.University;
+using EUniversity.Core.Models.University;
 using EUniversity.Core.Policy;
 using EUniversity.Core.Services.University;
 
 namespace EUniversity.IntegrationTests.Services.University;
 
 public class StudentSemestersServiceTests :
-    AssigningServiceTests<IStudentSemestersService, StudentSemester, int, string>
+    AssigningServiceTests<IStudentSemestersService, StudentSemester, int, StudentSemesterViewDto, int, string>
 {
     protected override async Task<int> GetIdOfExistingEntity1Async()
     {


### PR DESCRIPTION
This pull request introduces separate HTTP GET methods for retrieving enrollments at semesters and students in groups.

### Added GET endpoints
* `api/semesters/[semesterId]/students?page=&pageSize=`
* `api/groups/[groupId]/students?page=&pageSize=`

These additions offer a more granular approach to fetching data, allowing users to paginate through student records associated with a particular semester or group. This improvement prevents the need to retrieve all student data simultaneously when querying group or semester information by ID.

Due to this change, `api/semesters/[semesterId]` and `api/groups/[groupId]` will undergo a revision, no longer including associated students information in their responses.

### Other changes
* `EnrollmentDate` column was added to the `StudentGroups` table.
* Fake data generation was adapted to the previous change.