### PR TITLE
Add Creation and Update Dates

### DIFF
--- a/Core/Dtos/University/ClassroomViewDto.cs
+++ b/Core/Dtos/University/ClassroomViewDto.cs
@@ -1,3 +1,4 @@
 ﻿namespace EUniversity.Core.Dtos.University;
 
-public record ClassroomViewDto(int Id, string Name);
+public record ClassroomViewDto(int Id, string Name,
+    DateTimeOffset CreationDate, DateTimeOffset UpdateDate);

--- a/Core/Dtos/University/CoursePreviewDto.cs
+++ b/Core/Dtos/University/CoursePreviewDto.cs
@@ -1,3 +1,5 @@
 ﻿namespace EUniversity.Core.Dtos.University;
 
-public record CoursePreviewDto(int Id, string Name, SemesterMinimalViewDto? Semester);
+public record CoursePreviewDto(int Id, string Name, 
+    DateTimeOffset CreationDate, DateTimeOffset UpdateDate,
+    SemesterMinimalViewDto? Semester);

--- a/Core/Dtos/University/CourseViewDto.cs
+++ b/Core/Dtos/University/CourseViewDto.cs
@@ -1,3 +1,5 @@
 ﻿namespace EUniversity.Core.Dtos.University;
 
-public record CourseViewDto(int Id, string Name, string? Description, SemesterPreviewDto? Semester);
+public record CourseViewDto(int Id, string Name, string? Description, 
+    DateTimeOffset CreationDate, DateTimeOffset UpdateDate, 
+    SemesterPreviewDto? Semester);

--- a/Core/Dtos/University/Grades/GradeViewDto.cs
+++ b/Core/Dtos/University/Grades/GradeViewDto.cs
@@ -1,3 +1,4 @@
 ﻿namespace EUniversity.Core.Dtos.University.Grades;
 
-public record GradeViewDto(int Id, string Name, int Score);
+public record GradeViewDto(int Id, string Name, int Score, 
+    DateTimeOffset CreationDate, DateTimeOffset UpdateDate);

--- a/Core/Dtos/University/GroupPreviewDto.cs
+++ b/Core/Dtos/University/GroupPreviewDto.cs
@@ -2,4 +2,4 @@
 
 namespace EUniversity.Core.Dtos.University;
 
-public record GroupPreviewDto(int Id, string Name, TeacherPreviewDto? Teacher, CoursePreviewDto Course);
+public record GroupPreviewDto(int Id, string Name, DateTimeOffset CreationDate, DateTimeOffset UpdateDate, TeacherPreviewDto? Teacher, CoursePreviewDto Course);

--- a/Core/Dtos/University/GroupViewDto.cs
+++ b/Core/Dtos/University/GroupViewDto.cs
@@ -3,5 +3,6 @@
 namespace EUniversity.Core.Dtos.University;
 
 public record GroupViewDto(int Id, string Name,
+    DateTimeOffset CreationDate, DateTimeOffset UpdateDate,
     TeacherPreviewDto? Teacher, CoursePreviewDto Course,
     IEnumerable<StudentPreviewDto> Students);

--- a/Core/Dtos/University/SemesterPreviewDto.cs
+++ b/Core/Dtos/University/SemesterPreviewDto.cs
@@ -1,3 +1,5 @@
 ﻿namespace EUniversity.Core.Dtos.University;
 
-public record SemesterPreviewDto(int Id, string Name, DateTimeOffset DateFrom, DateTimeOffset DateTo);
+public record SemesterPreviewDto(int Id, string Name, 
+    DateTimeOffset CreationDate, DateTimeOffset UpdateDate,
+    DateTimeOffset DateFrom, DateTimeOffset DateTo);

--- a/Core/Dtos/University/SemesterViewDto.cs
+++ b/Core/Dtos/University/SemesterViewDto.cs
@@ -1,5 +1,6 @@
 ﻿namespace EUniversity.Core.Dtos.University;
 
 public record SemesterViewDto(int Id, string Name,
+    DateTimeOffset CreationDate, DateTimeOffset UpdateDate,
     DateTimeOffset DateFrom, DateTimeOffset DateTo,
     IEnumerable<StudentSemesterViewDto> StudentEnrollments);

--- a/Core/Models/IHasCreationDate.cs
+++ b/Core/Models/IHasCreationDate.cs
@@ -1,0 +1,12 @@
+﻿namespace EUniversity.Core.Models;
+
+/// <summary>
+/// An interface that defines an entity that has a creation date property.
+/// </summary>
+public interface IHasCreationDate
+{
+    /// <summary>
+    /// Date when the entity was created.
+    /// </summary>
+    public DateTimeOffset CreationDate { get; set; }
+}

--- a/Core/Models/IHasName.cs
+++ b/Core/Models/IHasName.cs
@@ -1,7 +1,7 @@
 ﻿namespace EUniversity.Core.Models;
 
 /// <summary>
-/// An interface that defines an object that have a Name property.
+/// An interface that defines an object that has a Name property.
 /// </summary>
 public interface IHasName
 {

--- a/Core/Models/IHasUpdateDate.cs
+++ b/Core/Models/IHasUpdateDate.cs
@@ -1,0 +1,12 @@
+﻿namespace EUniversity.Core.Models;
+
+/// <summary>
+/// An interface that defines an entity that has an update(edit) date property.
+/// </summary>
+public interface IHasUpdateDate
+{
+    /// <summary>
+    /// Date when the entity was last updated.
+    /// </summary>
+    public DateTimeOffset UpdateDate { get; set; }
+}

--- a/Core/Models/University/Classroom.cs
+++ b/Core/Models/University/Classroom.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Represents a classroom entity.
 /// </summary>
-public class Classroom : IEntity<int>, IHasName
+public class Classroom : IEntity<int>, IHasName, IHasCreationDate, IHasUpdateDate
 {
     public const int MaxNameLength = 50;
 
@@ -14,4 +14,13 @@ public class Classroom : IEntity<int>, IHasName
     /// </summary>
     [StringLength(MaxNameLength)]
     public string Name { get; set; } = null!;
+
+    /// <summary>
+    /// Date when the classroom was created.
+    /// </summary>
+    public DateTimeOffset CreationDate { get; set; }
+    /// <summary>
+    /// Date when the classroom was last updated.
+    /// </summary>
+    public DateTimeOffset UpdateDate { get; set; }
 }

--- a/Core/Models/University/Course.cs
+++ b/Core/Models/University/Course.cs
@@ -5,7 +5,7 @@ namespace EUniversity.Core.Models.University;
 /// <summary>
 /// Represents a course entity.
 /// </summary>
-public class Course : IEntity<int>, IHasName
+public class Course : IEntity<int>, IHasName, IHasCreationDate, IHasUpdateDate
 {
     public const int MaxNameLength = 200;
     public const int MaxDescriptionLength = 1000;
@@ -27,6 +27,15 @@ public class Course : IEntity<int>, IHasName
     /// </summary>
     [StringLength(MaxDescriptionLength)]
     public string? Description { get; set; }
+
+    /// <summary>
+    /// Date when the course was created.
+    /// </summary>
+    public DateTimeOffset CreationDate { get; set; }
+    /// <summary>
+    /// Date when the course was last updated.
+    /// </summary>
+    public DateTimeOffset UpdateDate { get; set; }
 
     /// <summary>
     /// Navigation property of the semester associated with this course(may be null).

--- a/Core/Models/University/Grades/Grade.cs
+++ b/Core/Models/University/Grades/Grade.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Represents an available grade entity that can be assigned to students.
 /// </summary>
-public class Grade : IEntity<int>, IHasName
+public class Grade : IEntity<int>, IHasName, IHasCreationDate, IHasUpdateDate
 {
     public const int MaxNameLength = 50;
 
@@ -18,6 +18,15 @@ public class Grade : IEntity<int>, IHasName
     /// Numeric value of the grade.
     /// </summary>
     public int Score { get; set; }
+
+    /// <summary>
+    /// Date when the grade was created.
+    /// </summary>
+    public DateTimeOffset CreationDate { get; set; }
+    /// <summary>
+    /// Date when the grade was last updated.
+    /// </summary>
+    public DateTimeOffset UpdateDate { get; set; }
 
     /// <summary>
     /// Navigation property: 

--- a/Core/Models/University/Group.cs
+++ b/Core/Models/University/Group.cs
@@ -6,7 +6,7 @@ namespace EUniversity.Core.Models.University;
 /// Represents a group entity, 
 /// which contains students with its own teacher and course.
 /// </summary>
-public class Group : IEntity<int>, IHasName
+public class Group : IEntity<int>, IHasName, IHasCreationDate, IHasUpdateDate
 {
     public const int MaxNameLength = 50;
 
@@ -27,6 +27,15 @@ public class Group : IEntity<int>, IHasName
     /// </summary>
     [ForeignKey(nameof(Teacher))]
     public string? TeacherId { get; set; }
+
+    /// <summary>
+    /// Date when the group was created.
+    /// </summary>
+    public DateTimeOffset CreationDate { get; set; }
+    /// <summary>
+    /// Date when the group was last updated.
+    /// </summary>
+    public DateTimeOffset UpdateDate { get; set; }
 
     /// <summary>
     /// Navigation property to the course associated with this group.

--- a/Core/Models/University/Semester.cs
+++ b/Core/Models/University/Semester.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// An entity that represents a semester.
 /// </summary>
-public class Semester : IEntity<int>, IHasName
+public class Semester : IEntity<int>, IHasName, IHasCreationDate, IHasUpdateDate
 {
     public const int MaxNameLength = 100;
 
@@ -22,6 +22,15 @@ public class Semester : IEntity<int>, IHasName
     /// Date when the semester ends.
     /// </summary>
     public DateTimeOffset DateTo { get; set; }
+
+    /// <summary>
+    /// Date when the semester was created.
+    /// </summary>
+    public DateTimeOffset CreationDate { get; set; }
+    /// <summary>
+    /// Date when the semester was last updated.
+    /// </summary>
+    public DateTimeOffset UpdateDate { get; set; }
 
     /// <summary>
     /// Navigation property to the students which are part of this semester.

--- a/Infrastructure/Extensions/FakerExtensions.cs
+++ b/Infrastructure/Extensions/FakerExtensions.cs
@@ -1,0 +1,16 @@
+﻿using Bogus;
+using EUniversity.Core.Models;
+
+namespace EUniversity.Infrastructure.Extensions;
+
+public static class FakerExtensions
+{
+    public static Faker<T> RuleForDates<T>(this Faker<T> faker)
+        where T : class, IHasCreationDate, IHasUpdateDate
+    {
+        return faker
+            .RuleFor(x => x.CreationDate, f => f.Date.RecentOffset(180))
+            .RuleFor(x => x.UpdateDate,
+            (f, x) => f.Date.BetweenOffset(x.CreationDate, x.CreationDate + TimeSpan.FromDays(90)));
+    }
+}

--- a/Infrastructure/Migrations/20231126163647_AddCreationAndUpdateDates.Designer.cs
+++ b/Infrastructure/Migrations/20231126163647_AddCreationAndUpdateDates.Designer.cs
@@ -4,6 +4,7 @@ using EUniversity.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EUniversity.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20231126163647_AddCreationAndUpdateDates")]
+    partial class AddCreationAndUpdateDates
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Infrastructure/Migrations/20231126163647_AddCreationAndUpdateDates.cs
+++ b/Infrastructure/Migrations/20231126163647_AddCreationAndUpdateDates.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EUniversity.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCreationAndUpdateDates : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "CreationDate",
+                table: "Semesters",
+                type: "datetimeoffset",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdateDate",
+                table: "Semesters",
+                type: "datetimeoffset",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "CreationDate",
+                table: "Groups",
+                type: "datetimeoffset",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdateDate",
+                table: "Groups",
+                type: "datetimeoffset",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "CreationDate",
+                table: "Grades",
+                type: "datetimeoffset",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdateDate",
+                table: "Grades",
+                type: "datetimeoffset",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "CreationDate",
+                table: "Courses",
+                type: "datetimeoffset",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdateDate",
+                table: "Courses",
+                type: "datetimeoffset",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "CreationDate",
+                table: "Classrooms",
+                type: "datetimeoffset",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdateDate",
+                table: "Classrooms",
+                type: "datetimeoffset",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreationDate",
+                table: "Semesters");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateDate",
+                table: "Semesters");
+
+            migrationBuilder.DropColumn(
+                name: "CreationDate",
+                table: "Groups");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateDate",
+                table: "Groups");
+
+            migrationBuilder.DropColumn(
+                name: "CreationDate",
+                table: "Grades");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateDate",
+                table: "Grades");
+
+            migrationBuilder.DropColumn(
+                name: "CreationDate",
+                table: "Courses");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateDate",
+                table: "Courses");
+
+            migrationBuilder.DropColumn(
+                name: "CreationDate",
+                table: "Classrooms");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateDate",
+                table: "Classrooms");
+        }
+    }
+}

--- a/Infrastructure/Services/BaseCrudService.cs
+++ b/Infrastructure/Services/BaseCrudService.cs
@@ -48,6 +48,16 @@ public abstract class BaseCrudService<TEntity, TId, TPreviewDto, TDetailsDto, TC
     public virtual async Task<TEntity> CreateAsync(TCreateDto dto)
     {
         TEntity entity = dto.Adapt<TEntity>();
+        // Set a creation date(if possible)
+        if (entity is IHasCreationDate entityWithCreationDate)
+        {
+            entityWithCreationDate.CreationDate = DateTimeOffset.Now;
+        }
+        // Set an update date(if possible)
+        if (entity is IHasUpdateDate entityWithUpdateDate)
+        {
+            entityWithUpdateDate.UpdateDate = DateTimeOffset.Now;
+        }
         DbContext.Set<TEntity>().Add(entity);
         await DbContext.SaveChangesAsync();
 
@@ -98,6 +108,11 @@ public abstract class BaseCrudService<TEntity, TId, TPreviewDto, TDetailsDto, TC
 
         // Update the entity
         dto.Adapt(entity);
+        // Set an update date(if possible)
+        if (entity is IHasUpdateDate entityWithUpdateDate)
+        {
+            entityWithUpdateDate.UpdateDate = DateTimeOffset.Now;
+        }
         DbContext.Update(entity);
         await DbContext.SaveChangesAsync();
 

--- a/Infrastructure/Services/Test/TestDataService.cs
+++ b/Infrastructure/Services/Test/TestDataService.cs
@@ -6,6 +6,7 @@ using EUniversity.Core.Models.University.Grades;
 using EUniversity.Core.Policy;
 using EUniversity.Core.Services.Auth;
 using EUniversity.Infrastructure.Data;
+using EUniversity.Infrastructure.Extensions;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 
@@ -96,7 +97,7 @@ public class TestDataService
         await _authService.RegisterManyAsync(usersFaker.GenerateLazy(teachers), Roles.Teacher)
             .ToListAsync();
         // Register students
-        _logger.LogInformation("Generating {students} teachers", students);
+        _logger.LogInformation("Generating {students} students", students);
         await _authService.RegisterManyAsync(usersFaker.GenerateLazy(students), Roles.Student)
             .ToListAsync();
 
@@ -137,7 +138,8 @@ public class TestDataService
         var classroomsFaker = new Faker<Classroom>()
             .RuleFor(c => c.Name, f =>
                 new string(f.Random.Chars('A', 'Z', f.Random.Number(0, 3))) +
-                new string(f.Random.Chars('0', '9', 5)));
+                new string(f.Random.Chars('0', '9', 5)))
+            .RuleForDates();
 
         await CreateFakeEntitiesAsync(classroomsFaker, count);
     }
@@ -150,7 +152,8 @@ public class TestDataService
         int grade = 1;
         var gradesFaker = new Faker<Grade>()
             .RuleFor(g => g.Score, f => grade++)
-            .RuleFor(g => g.Name, (f, g) => g.Score.ToString());
+            .RuleFor(g => g.Name, (f, g) => g.Score.ToString())
+            .RuleForDates();
 
         await CreateFakeEntitiesAsync(gradesFaker, count);
     }
@@ -170,7 +173,8 @@ public class TestDataService
             .RuleFor(c => c.Name, f => f.Company.CatchPhrase())
             .RuleFor(c => c.Description, f => f.Lorem.Sentences(f.Random.Number(1, 3), " "))
             // Random teacher ID(90% probabilty) or null
-            .RuleFor(c => c.SemesterId, f => f.Random.Bool(0.9f) ? f.Random.CollectionItem(teachersIds) : null);
+            .RuleFor(c => c.SemesterId, f => f.Random.Bool(0.9f) ? f.Random.CollectionItem(teachersIds) : null)
+            .RuleForDates();
 
         await CreateFakeEntitiesAsync(coursesFaker, count);
     }
@@ -199,11 +203,12 @@ public class TestDataService
         var groupsFaker = new Faker<Group>()
             .RuleFor(g => g.Name, f => f.Random.AlphaNumeric(6))
             .RuleFor(g => g.CourseId, f => f.Random.CollectionItem(coursesIds))
-            .RuleFor(g => g.TeacherId, f => f.Random.CollectionItem(teachersIds));
+            .RuleFor(g => g.TeacherId, f => f.Random.CollectionItem(teachersIds))
+            .RuleForDates();
         await CreateFakeEntitiesAsync(groupsFaker, count);
 
         // Get all groups
-        var groupsIds = _dbContext.Semesters
+        var groupsIds = _dbContext.Groups
             .Select(g => g.Id)
             .ToArray();
 
@@ -253,7 +258,8 @@ public class TestDataService
             .RuleFor(s => s.DateFrom, f => f.Date.Between(minDate, maxDate))
             .RuleFor(s => s.DateTo, (f, s) => f.Date.Between(s.DateFrom.DateTime,
             s.DateFrom.DateTime + TimeSpan.FromDays(180)))
-            .RuleFor(s => s.Name, (f, s) => $"Semester {number++} {s.DateFrom:yyyy-MM-dd}-{s.DateTo:yyyy-MM-dd}");
+            .RuleFor(s => s.Name, (f, s) => $"Semester {number++} {s.DateFrom:yyyy-MM-dd}-{s.DateTo:yyyy-MM-dd}")
+            .RuleForDates();
         await CreateFakeEntitiesAsync(semestersFaker, count);
 
         // Get all semesters

--- a/IntegrationTests/Controllers/University/ClassroomsControllerTests.cs
+++ b/IntegrationTests/Controllers/University/ClassroomsControllerTests.cs
@@ -28,12 +28,12 @@ public class ClassroomsControllerTests :
 
     protected override ClassroomViewDto GetTestPreviewDto()
     {
-        return new(1, "Test");
+        return new(1, "Test", DateTimeOffset.Now, DateTimeOffset.Now);
     }
 
     protected override ClassroomViewDto GetTestDetailsDto()
     {
-        return new(2, "Test classroom");
+        return new(2, "Test classroom", DateTimeOffset.Now, DateTimeOffset.Now);
     }
 
     protected override ClassroomCreateDto GetInvalidCreateDto()

--- a/IntegrationTests/Controllers/University/CoursesControllerTests.cs
+++ b/IntegrationTests/Controllers/University/CoursesControllerTests.cs
@@ -47,14 +47,15 @@ public class CoursesControllerTests :
     protected override CourseViewDto GetTestDetailsDto()
     {
         SemesterPreviewDto semester = new(4, "Test semester",
-            DateTimeOffset.MinValue, DateTimeOffset.MaxValue);
-        return new(DefaultId, "Test", null, semester);
+            DateTimeOffset.MinValue, DateTimeOffset.MaxValue, 
+            DateTimeOffset.Now, DateTimeOffset.Now);
+        return new(DefaultId, "Test", null, DateTimeOffset.Now, DateTimeOffset.Now, semester);
     }
 
     protected override CoursePreviewDto GetTestPreviewDto()
     {
         SemesterMinimalViewDto semester = new(4, "Test semester");
-        return new(DefaultId, "Test", semester);
+        return new(DefaultId, "Test", DateTimeOffset.Now, DateTimeOffset.Now, semester);
     }
 
     protected override CourseCreateDto GetValidCreateDto()

--- a/IntegrationTests/Controllers/University/Grades/GradesControllerTests.cs
+++ b/IntegrationTests/Controllers/University/Grades/GradesControllerTests.cs
@@ -28,12 +28,12 @@ public class GradesControllerTestsAdminCrudControllersTest :
 
     protected override GradeViewDto GetTestPreviewDto()
     {
-        return new(1, "100", 100);
+        return new(1, "100", 100, DateTimeOffset.Now, DateTimeOffset.Now);
     }
 
     protected override GradeViewDto GetTestDetailsDto()
     {
-        return new(2, "100", 100);
+        return new(2, "100", 100, DateTimeOffset.Now, DateTimeOffset.Now);
     }
 
     protected override GradeCreateDto GetInvalidCreateDto()

--- a/IntegrationTests/Controllers/University/GroupsControllerTests.cs
+++ b/IntegrationTests/Controllers/University/GroupsControllerTests.cs
@@ -10,7 +10,7 @@ public class GroupsControllerTests :
     AdminCrudControllersTest<Group, int, GroupPreviewDto, GroupViewDto, GroupCreateDto, GroupCreateDto>
 {
     public readonly TeacherPreviewDto TeacherPreviewDto = new(Guid.NewGuid().ToString(), "test-teacher", "Teacher1", "Teacher2", null);
-    public readonly CoursePreviewDto CoursePreviewDto = new(5, "Some Course", null);
+    public readonly CoursePreviewDto CoursePreviewDto = new(5, "Some Course", DateTimeOffset.Now, DateTimeOffset.Now, null);
 
     public override string GetPageRoute => "api/groups";
 
@@ -61,13 +61,17 @@ public class GroupsControllerTests :
         {
             new(Guid.NewGuid().ToString(), "test-user", "Student1", "Student2", null)
         };
-        return new(DefaultId, "Group", TeacherPreviewDto,
+        return new(DefaultId, "Group",
+            DateTimeOffset.Now, DateTimeOffset.Now,
+            TeacherPreviewDto,
             CoursePreviewDto, students);
     }
 
     protected override GroupPreviewDto GetTestPreviewDto()
     {
-        return new(DefaultId, "Group", TeacherPreviewDto, CoursePreviewDto);
+        return new(DefaultId, "Group", 
+            DateTimeOffset.Now, DateTimeOffset.Now, 
+            TeacherPreviewDto, CoursePreviewDto);
     }
 
     protected override GroupCreateDto GetValidCreateDto()

--- a/IntegrationTests/Controllers/University/SemestersControllerTests.cs
+++ b/IntegrationTests/Controllers/University/SemestersControllerTests.cs
@@ -61,12 +61,16 @@ public class SemestersControllerTests :
         {
             new(student, DateTimeOffset.Now)
         };
-        return new(DefaultId, "Test semester", DateTimeOffset.MinValue, DateTimeOffset.MaxValue, enrollments);
+        return new(DefaultId, "Test semester",
+           DateTimeOffset.Now, DateTimeOffset.Now,
+            DateTimeOffset.MinValue, DateTimeOffset.MaxValue, enrollments);
     }
 
     protected override SemesterPreviewDto GetTestPreviewDto()
     {
-        return new(DefaultId, "Test semester", DateTimeOffset.MinValue, DateTimeOffset.MaxValue);
+        return new(DefaultId, "Test semester",
+            DateTimeOffset.Now, DateTimeOffset.Now,
+            DateTimeOffset.MinValue, DateTimeOffset.MaxValue);
     }
 
     protected override SemesterCreateDto GetValidCreateDto()


### PR DESCRIPTION
This pull request adds `CreationDate` and `UpdateDate` properties to entities.

### Changes made
* Introduced `IHasUpdateDate` and `IHasCreationDate` interfaces.
* Updated `BaseCrudService` to set creation date and/or update date to entities.
* Added date properties to all related DTOs. 
* Enhanced test data generation.
* Wrote tests for new changes.

### Affected entities
* Classroom
* Course
* Grade
* Group
* Semester

### Affected endpoints
* GET `api/classrooms`
* GET `api/classrooms/[id]`
* GET `api/courses`
* GET `api/courses/[id]`
* GET `api/grades`
* GET `api/grades/[id]`
* GET `api/groups`
* GET `api/groups/[id]`
* GET `api/semesters`
* GET `api/semesters/[id]`