### PR TITLE
Extend Users Filter

### DIFF
--- a/EUniversity.Tests/Filters/UsersFilterTests.cs
+++ b/EUniversity.Tests/Filters/UsersFilterTests.cs
@@ -90,4 +90,68 @@ public class UsersFilterTests
         // Assert
         Assert.That(result.Select(u => u.Id), Is.EquivalentTo(expectedUsersIds));
     }
+
+    private readonly ApplicationUser[] testArray =
+    {
+            new ApplicationUser() { Id = "2", UserName="jock666", FirstName = "John", LastName = "Doe"},
+            new ApplicationUser() { Id = "3", UserName="shy_girl", FirstName = "Alice", MiddleName = "Diana", LastName = "Johnson"},
+            new ApplicationUser() { Id = "1", UserName="nerd777", FirstName = "Bob", MiddleName = "Walter", LastName = "Black"},
+            new ApplicationUser() { Id = "4", UserName="cat", FirstName = "Adam", LastName = "Doe"}
+    };
+
+    [Test]
+    public void NameSortingMode_ReturnsSortedByFirstNameQuery()
+    {
+        // Arrange
+        UsersFilterProperties properties = new(SortingMode: UsersSortingMode.FullName);
+        UsersFilter filter = new(properties);
+
+        // Act
+        var result = filter.Apply(testArray.AsQueryable());
+
+        // Assert
+        Assert.That(result, Is.Ordered.Ascending.By("FirstName"));
+    }
+
+    [Test]
+    public void NameDescendingSortingMode_ReturnsSortedDescendingByFirstNameQuery()
+    {
+        // Arrange
+        UsersFilterProperties properties = new(SortingMode: UsersSortingMode.FullNameDescending);
+        UsersFilter filter = new(properties);
+
+        // Act
+        var result = filter.Apply(testArray.AsQueryable());
+
+        // Assert
+        Assert.That(result, Is.Ordered.Descending.By("FirstName"));
+    }
+
+    [Test]
+    public void UserNameDescendingSortingMode_ReturnsSortedByUserNameQuery()
+    {
+        // Arrange
+        UsersFilterProperties properties = new(SortingMode: UsersSortingMode.UserName);
+        UsersFilter filter = new(properties);
+
+        // Act
+        var result = filter.Apply(testArray.AsQueryable());
+
+        // Assert
+        Assert.That(result, Is.Ordered.Ascending.By("UserName"));
+    }
+
+    [Test]
+    public void UserNameDescendingSortingMode_ReturnsSortedDescendingByUserNameQuery()
+    {
+        // Arrange
+        UsersFilterProperties properties = new(SortingMode: UsersSortingMode.UserNameDescending);
+        UsersFilter filter = new(properties);
+
+        // Act
+        var result = filter.Apply(testArray.AsQueryable());
+
+        // Assert
+        Assert.That(result, Is.Ordered.Descending.By("UserName"));
+    }
 }

--- a/EUniversity/Controllers/UsersController.cs
+++ b/EUniversity/Controllers/UsersController.cs
@@ -29,6 +29,18 @@ public class UsersController : ControllerBase
     /// <summary>
     /// Gets a page with users.
     /// </summary>
+    /// <remarks>
+    /// If there is no items in the requested page, then empty page will be returned.
+    /// <br />
+    /// 'sortingMode' is an optional query param that accepts one of these values
+    /// <ul>
+    /// <li>default(or 0) - no sorting will be applied;</li>
+    /// <li>fullName(or 1) - users will be sorted by their full name(from a to z), this mode is applied by default;</li>
+    /// <li>fullNameDescending(or 2) - users will be sorted by their full name in descending order(from z to a);</li>
+    /// <li>username(or 3) - users will be sorted by their username(from a to z), this mode is applied by default;</li>
+    /// <li>usernameDescending(or 4) - users will be sorted by their username in descending order(from z to a).</li>
+    /// </ul>
+    /// </remarks>
     /// <response code="200">Returns a page with users</response>
     /// <response code="401">Unauthorized user call</response>
     /// <response code="403">User lacks 'Administrator' role</response>
@@ -47,6 +59,18 @@ public class UsersController : ControllerBase
     /// <summary>
     /// Gets a page with students.
     /// </summary>
+    /// <remarks>
+    /// If there is no items in the requested page, then empty page will be returned.
+    /// <br />
+    /// 'sortingMode' is an optional query param that accepts one of these values
+    /// <ul>
+    /// <li>default(or 0) - no sorting will be applied;</li>
+    /// <li>fullName(or 1) - students will be sorted by their full name(from a to z), this mode is applied by default;</li>
+    /// <li>fullNameDescending(or 2) - students will be sorted by their full name in descending order(from z to a);</li>
+    /// <li>username(or 3) - students will be sorted by their username(from a to z), this mode is applied by default;</li>
+    /// <li>usernameDescending(or 4) - students will be sorted by their username in descending order(from z to a).</li>
+    /// </ul>
+    /// </remarks>
     /// <response code="200">Returns a page with students</response>
     /// <response code="401">Unauthorized user call</response>
     /// <response code="403">User lacks 'Administrator' role</response>
@@ -66,6 +90,18 @@ public class UsersController : ControllerBase
     /// <summary>
     /// Gets a page with teachers.
     /// </summary>
+    /// <remarks>
+    /// If there is no items in the requested page, then empty page will be returned.
+    /// <br />
+    /// 'sortingMode' is an optional query param that accepts one of these values
+    /// <ul>
+    /// <li>default(or 0) - no sorting will be applied;</li>
+    /// <li>fullName(or 1) - teachers will be sorted by their full name(from a to z), this mode is applied by default;</li>
+    /// <li>fullNameDescending(or 2) - teachers will be sorted by their full name in descending order(from z to a);</li>
+    /// <li>username(or 3) - teachers will be sorted by their username(from a to z), this mode is applied by default;</li>
+    /// <li>usernameDescending(or 4) - teachers will be sorted by their username in descending order(from z to a).</li>
+    /// </ul>
+    /// </remarks>
     /// <response code="200">Returns a page with teachers</response>
     /// <response code="401">Unauthorized user call</response>
     /// <response code="403">User lacks 'Administrator' role</response>

--- a/Infrastructure/Filters/UsersFilter.cs
+++ b/Infrastructure/Filters/UsersFilter.cs
@@ -1,5 +1,6 @@
 ﻿using EUniversity.Core.Filters;
 using EUniversity.Core.Models;
+using System.Linq.Expressions;
 
 namespace EUniversity.Infrastructure.Filters;
 
@@ -9,6 +10,9 @@ namespace EUniversity.Infrastructure.Filters;
 public class UsersFilter : IFilter<ApplicationUser>
 {
     public UsersFilterProperties Properties { get; }
+
+    private Expression<Func<ApplicationUser, string>> FullNameKeySelector =
+        u => u.FirstName + ' ' + (u.MiddleName != null ? u.MiddleName + ' ' : "") + u.LastName;
 
     /// <summary>
     /// Initializes a new instance of the class with the specified properties.
@@ -28,6 +32,7 @@ public class UsersFilter : IFilter<ApplicationUser>
     /// </returns>
     public IQueryable<ApplicationUser> Apply(IQueryable<ApplicationUser> query)
     {
+        // Filtering
         if (Properties.FullName != null)
         {
             query = query.Where(
@@ -43,6 +48,24 @@ public class UsersFilter : IFilter<ApplicationUser>
         {
             query = query.Where(u => u.UserName != null && u.UserName.Contains(Properties.UserName));
         }
+
+        // Sorting
+        switch (Properties.SortingMode)
+        {
+            case UsersSortingMode.FullName:
+                query = query.OrderBy(FullNameKeySelector);
+                break;
+            case UsersSortingMode.FullNameDescending:
+                query = query.OrderByDescending(FullNameKeySelector);
+                break;
+            case UsersSortingMode.UserName:
+                query = query.OrderBy(u => u.UserName);
+                break;
+            case UsersSortingMode.UserNameDescending:
+                query = query.OrderByDescending(u => u.UserName);
+                break;
+        }
+
         return query;
     }
 }

--- a/Infrastructure/Filters/UsersFilterProperties.cs
+++ b/Infrastructure/Filters/UsersFilterProperties.cs
@@ -1,9 +1,41 @@
 ﻿namespace EUniversity.Infrastructure.Filters;
 
 /// <summary>
+/// Represents a sorting mode for <see cref="UsersFilter" />.
+/// </summary>
+public enum UsersSortingMode
+{
+    /// <summary>
+    /// Default sorting mode, users will not be sorted.
+    /// </summary>
+    Default = 0,
+    /// <summary>
+    /// Sort users by fullname alphabetically from a to z.
+    /// </summary>
+    FullName = 1,
+    /// <summary>
+    /// Sort users by fullname alphabetically from z to a. 
+    /// </summary>
+    FullNameDescending = 2,
+    /// <summary>
+    /// Sort users by username alphabetically from a to z.
+    /// </summary>
+    UserName = 3,
+    /// <summary>
+    /// Sort users by username alphabetically from z to a. 
+    /// </summary>
+    UserNameDescending = 4
+}
+
+/// <summary>
 /// Represents properties for filtering users.
 /// </summary>
 /// <param name="FullName">Optional full name to filter by.</param>
 /// <param name="UserName">Optional username to filter by.</param>
 /// <param name="Email">Optional email to filter by.</param>
-public record UsersFilterProperties(string? FullName = null, string? UserName = null, string? Email = null);
+/// <param name="SortingMode">
+/// Optional sorting mode, <see cref="UsersSortingMode.FullName"/> by default.
+/// </param>
+public record UsersFilterProperties(string? FullName = null, 
+    string? UserName = null, string? Email = null,
+    UsersSortingMode SortingMode = UsersSortingMode.FullName);

--- a/IntegrationTests/Controllers/UsersControllerTests.cs
+++ b/IntegrationTests/Controllers/UsersControllerTests.cs
@@ -31,8 +31,8 @@ public class UsersControllerTests : ControllersTest
         new("2", "mail2@example.com", "user2", "First2", "Last2", "Middle2")
     };
 
-    public UsersFilterProperties TestFilterProperties = new("Joe Doe", "joedoe777", "mail@example.com");
-    public const string TestFilterQuery = "fullName=Joe%20Doe&userName=joedoe777&email=mail@example.com";
+    public UsersFilterProperties TestFilterProperties = new("Joe Doe", "joedoe777", "mail@example.com", UsersSortingMode.UserName);
+    public const string TestFilterQuery = "fullName=Joe%20Doe&userName=joedoe777&email=mail@example.com&sortingMode=username";
 
     public static readonly string[] GetMethods =
     {


### PR DESCRIPTION
This pull request extends `UsersFilter` by adding sorting mode to it. GET users endpoints now support sorting by full name or username.

### Affected endpoints
* GET `api/users`
* GET `api/users/students`
* GET `api/users/teachers`

Swagger documentation for these endpoints was updated.