### PR TITLE
Add Semesters Filter

### DIFF
--- a/EUniversity.Tests/Filters/SemestersFilterTests.cs
+++ b/EUniversity.Tests/Filters/SemestersFilterTests.cs
@@ -1,0 +1,70 @@
+﻿using EUniversity.Core.Models.University;
+using EUniversity.Infrastructure.Filters;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EUniversity.Tests.Filters;
+
+public class SemestersFilterTests
+{
+    private readonly Semester[] TestSemesters =
+    {
+        new Semester() {Id = 1, Name = "Semester I", DateFrom = new(1L, TimeSpan.Zero), DateTo = new(100L, TimeSpan.Zero)},
+        new Semester() {Id = 2, Name = "Semester II", DateFrom = new(50L, TimeSpan.Zero), DateTo = new(150L, TimeSpan.Zero)},
+        new Semester() {Id = 3, Name = "Semester III", DateFrom = new(101L, TimeSpan.Zero), DateTo = new(200L, TimeSpan.Zero)}
+    };
+
+    [Test]
+    public void EmptyFilter_ReturnsQuery()
+    {
+        // Arrange
+        SemestersFilterProperties properties = new();
+        SemestersFilter filter = new(properties, string.Empty);
+
+        // Act
+        var result = filter
+            .Apply(TestSemesters.AsQueryable());
+
+        // Arrange
+        Assert.That(result, Is.EquivalentTo(TestSemesters));
+    }
+
+    [Test]
+    public void MaxDateFromSpecified_ReturnsFilteredQuery()
+    {
+        // Arrange
+        DateTimeOffset date = new(75L, TimeSpan.Zero);
+        SemestersFilterProperties properties = new(MaxDateFrom: date);
+        SemestersFilter filter = new(properties, string.Empty);
+        int[] expectedIds = { 1, 2 };
+
+        // Act
+        var actualIds = filter
+            .Apply(TestSemesters.AsQueryable())
+            .Select(s => s.Id);
+
+        // Assert
+        Assert.That(actualIds, Is.EquivalentTo(expectedIds));
+    }
+
+    [Test]
+    public void MinDateToSpecified_ReturnsFilteredQuery()
+    {
+        // Arrange
+        DateTimeOffset date = new(125L, TimeSpan.Zero);
+        SemestersFilterProperties properties = new(MinDateTo: date);
+        SemestersFilter filter = new(properties, string.Empty);
+        int[] expectedIds = { 2, 3 };
+
+        // Act
+        var actualIds = filter
+            .Apply(TestSemesters.AsQueryable())
+            .Select(s => s.Id);
+
+        // Assert
+        Assert.That(actualIds, Is.EquivalentTo(expectedIds));
+    }
+}

--- a/EUniversity/Controllers/University/SemestersController.cs
+++ b/EUniversity/Controllers/University/SemestersController.cs
@@ -41,6 +41,7 @@ public class SemestersController : ControllerBase
     /// If there is no items in the requested page, then empty page will be returned.
     /// </remarks>
     /// <param name="properties">Pagination properties.</param>
+    /// <param name="filterProperties">Semesters filter properties.</param>
     /// <param name="name">An optional name to filter semesters by.</param>
     /// <param name="sortingMode">
     /// An optional sorting mode.
@@ -65,10 +66,11 @@ public class SemestersController : ControllerBase
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> GetSemestersPageAsync(
         [FromQuery] PaginationProperties properties,
+        [FromQuery] SemestersFilterProperties filterProperties,
         [FromQuery] string? name,
         [FromQuery] DefaultFilterSortingMode sortingMode = DefaultFilterSortingMode.Name)
     {
-        DefaultFilter<Semester> filter = new(name ?? string.Empty, sortingMode);
+        SemestersFilter filter = new(filterProperties, name ?? string.Empty, sortingMode);
         return Ok(await _semestersService.GetPageAsync(properties, filter));
     }
 

--- a/Infrastructure/Filters/DefaultFilter.cs
+++ b/Infrastructure/Filters/DefaultFilter.cs
@@ -69,7 +69,7 @@ public class DefaultFilter<T> : IFilter<T>
     /// <returns>
     /// Filtered and sorted query that contains entities with a matched name.
     /// </returns>
-    public IQueryable<T> Apply(IQueryable<T> query)
+    public virtual IQueryable<T> Apply(IQueryable<T> query)
     {
         // Filter by name
         query = query.Where(x => x.Name.Contains(Name));

--- a/Infrastructure/Filters/SemestersFilter.cs
+++ b/Infrastructure/Filters/SemestersFilter.cs
@@ -1,0 +1,37 @@
+﻿using EUniversity.Core.Models.University;
+
+namespace EUniversity.Infrastructure.Filters;
+
+/// <summary>
+/// Filter for classes.
+/// </summary>
+public class SemestersFilter : DefaultFilter<Semester>
+{
+    /// <summary>
+    /// Properties of filtering.
+    /// </summary>
+    public SemestersFilterProperties Properties { get; }
+
+    public SemestersFilter(SemestersFilterProperties properties, string name,
+        DefaultFilterSortingMode sortingMode = DefaultFilterSortingMode.Default) :
+        base(name, sortingMode)
+    {
+        Properties = properties;
+    }
+
+    /// <inheritdoc />
+    public override IQueryable<Semester> Apply(IQueryable<Semester> query)
+    {
+        // Apply semesters filter
+        if (Properties.MaxDateFrom != null)
+        {
+            query = query.Where(s => s.DateFrom <= Properties.MaxDateFrom);
+        }
+        if (Properties.MinDateTo != null)
+        {
+            query = query.Where(s => s.DateTo >= Properties.MinDateTo);
+        }
+        // Apply default filter
+        return base.Apply(query);
+    }
+}

--- a/Infrastructure/Filters/SemestersFilterProperties.cs
+++ b/Infrastructure/Filters/SemestersFilterProperties.cs
@@ -1,0 +1,9 @@
+﻿namespace EUniversity.Infrastructure.Filters;
+
+/// <summary>
+/// Represents properties for filtering semesters.
+/// </summary>
+/// <param name="MaxDateFrom">Minimum start date of the semester to filter by.</param>
+/// <param name="MinDateTo">Maximum start date of the semester to filter by.</param>
+public record SemestersFilterProperties(DateTimeOffset? MaxDateFrom = null, 
+    DateTimeOffset? MinDateTo = null);

--- a/IntegrationTests/Controllers/University/SemestersControllerTests.cs
+++ b/IntegrationTests/Controllers/University/SemestersControllerTests.cs
@@ -42,9 +42,9 @@ public class SemestersControllerTests :
 
     protected override bool AssertThatFilterWasApplied(IFilter<Semester> filter)
     {
-        return filter is DefaultFilter<Semester> defaultFilter &&
-            defaultFilter.Name == "testfilter" &&
-            defaultFilter.SortingMode == DefaultFilterSortingMode.Name;
+        return filter is SemestersFilter semestersFilter &&
+            semestersFilter.Name == "testfilter" &&
+            semestersFilter.SortingMode == DefaultFilterSortingMode.Name;
     }
 
     protected override SemesterCreateDto GetInvalidCreateDto()


### PR DESCRIPTION
This pull requests adds a filter for semesters, which is inherited from `DefaultFilter`. The filter has two new properties: `MaxDateFrom` and `MinDateTo`.

### Affected endpoints
* GET `api/semesters`