### PR TITLE
Add Groups Filter

### DIFF
--- a/EUniversity.Tests/Filters/ClassesFilterTests.cs
+++ b/EUniversity.Tests/Filters/ClassesFilterTests.cs
@@ -85,7 +85,7 @@ public class ClassesFilterTests
         return @class;
     }
 
-    private Class[] TestClasses =
+    private readonly Class[] TestClasses =
     {
         GetClass(1, TestClassType1, TestClassroom1, TestGroup1, new(3L, TimeSpan.Zero)),
         GetClass(2, TestClassType1, TestClassroom1, TestGroup1, new(1L, TimeSpan.Zero), TestSubstituteTeacher),

--- a/EUniversity.Tests/Filters/GroupsFilterTests.cs
+++ b/EUniversity.Tests/Filters/GroupsFilterTests.cs
@@ -1,0 +1,125 @@
+﻿using EUniversity.Core.Models;
+using EUniversity.Core.Models.University;
+using EUniversity.Infrastructure.Filters;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EUniversity.Tests.Filters;
+
+public class GroupsFilterTests
+{
+    private static readonly Semester TestSemester = new()
+    {
+        Id = 100
+    };
+
+    private static readonly ApplicationUser TestTeacher1 = new()
+    {
+        Id = "test-teacher-id1"
+    };
+    private static readonly ApplicationUser TestTeacher2 = new()
+    {
+        Id = "test-teacher-id2"
+    };
+
+    private static readonly Course CourseWithSemester = new()
+    {
+        Id = 200,
+        Semester = TestSemester,
+        SemesterId = TestSemester.Id
+    };
+    private static readonly Course NoSemesterCourse = new()
+    {
+        Id = 201
+    };
+
+    private static readonly Group[] TestGroups =
+    {
+        new Group() {Id = 300, Name = "Group I", Course = CourseWithSemester, CourseId = CourseWithSemester.Id, Teacher = TestTeacher2, TeacherId = TestTeacher2.Id},
+        new Group() {Id = 301, Name = "Group II", Course = NoSemesterCourse, CourseId = NoSemesterCourse.Id, Teacher = TestTeacher2, TeacherId = TestTeacher2.Id},
+        new Group() {Id = 302, Name = "Group III", Course = CourseWithSemester, CourseId = CourseWithSemester.Id, Teacher = TestTeacher1, TeacherId = TestTeacher1.Id},
+        new Group() {Id = 303, Name = "Group IV", Course = NoSemesterCourse, CourseId = NoSemesterCourse.Id, Teacher = TestTeacher1, TeacherId = TestTeacher1.Id}
+    };
+
+    [Test]
+    public void EmptyFilter_ReturnsEntireQuery()
+    {
+        // Arrange
+        GroupsFilterProperties properties = new();
+        GroupsFilter filter = new(properties, string.Empty);
+
+        // Act
+        var result = filter.Apply(TestGroups.AsQueryable());
+
+        // Assert
+        Assert.That(result, Is.EquivalentTo(TestGroups));
+    }
+
+    [Test]
+    public void TeacherIdSpecified_ReturnsFilteredQuery()
+    {
+        // Arrange
+        GroupsFilterProperties properties = new(TeacherId: TestTeacher1.Id);
+        GroupsFilter filter = new(properties, string.Empty);
+        int[] expectedIds = { 302, 303 };
+
+        // Act
+        var actualIds = filter.Apply(TestGroups.AsQueryable())
+            .Select(g => g.Id);
+
+        // Assert
+        Assert.That(actualIds, Is.EquivalentTo(expectedIds));
+    }
+
+    [Test]
+    public void CourseIdSpecified_ReturnsFilteredQuery()
+    {
+        // Arrange
+        GroupsFilterProperties properties = new(CourseId: CourseWithSemester.Id);
+        GroupsFilter filter = new(properties, string.Empty);
+        int[] expectedIds = { 300, 302 };
+
+        // Act
+        var query = TestGroups.AsQueryable();
+        var actualIds = filter.Apply(query)
+            .Select(g => g.Id);
+
+        // Assert
+        Assert.That(actualIds, Is.EquivalentTo(expectedIds));
+    }
+
+    [Test]
+    public void SemesterIdSpecified_ReturnsFilteredQuery()
+    {
+        // Arrange
+        GroupsFilterProperties properties = new(SemesterId: TestSemester.Id);
+        GroupsFilter filter = new(properties, string.Empty);
+        int[] expectedIds = { 300, 302 };
+
+        // Act
+        var actualIds = filter.Apply(TestGroups.AsQueryable())
+            .Select(g => g.Id);
+
+        // Assert
+        Assert.That(actualIds, Is.EquivalentTo(expectedIds));
+    }
+
+    [Test]
+    public void ZeroSemesterId_ReturnsGroupsWithoutSemesters()
+    {
+        // Arrange
+        GroupsFilterProperties properties = new(SemesterId: 0);
+        GroupsFilter filter = new(properties, string.Empty);
+        int[] expectedIds = { 301, 303 };
+
+        // Act
+        var actualIds = filter.Apply(TestGroups.AsQueryable())
+            .Select(g => g.Id);
+
+        // Assert
+        Assert.That(actualIds, Is.EquivalentTo(expectedIds));
+    }
+}

--- a/EUniversity/Controllers/University/GroupsController.cs
+++ b/EUniversity/Controllers/University/GroupsController.cs
@@ -39,8 +39,10 @@ public class GroupsController : ControllerBase
     /// </summary>
     /// <remarks>
     /// If there is no items in the requested page, then empty page will be returned.
+    /// If the query param 'semesterId' is 0, then groups that are not linked to any semesters will be returned.
     /// </remarks>
     /// <param name="properties">Pagination properties.</param>
+    /// <param name="filterProperties">Filter properties.</param>
     /// <param name="name">An optional name to filter groups by.</param>
     /// <param name="sortingMode">
     /// An optional sorting mode.
@@ -65,10 +67,11 @@ public class GroupsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> GetGroupsPageAsync(
         [FromQuery] PaginationProperties properties,
+        [FromQuery] GroupsFilterProperties filterProperties,
         [FromQuery] string? name,
         [FromQuery] DefaultFilterSortingMode sortingMode = DefaultFilterSortingMode.Name)
     {
-        DefaultFilter<Group> filter = new(name ?? string.Empty, sortingMode);
+        GroupsFilter filter = new(filterProperties, name ?? string.Empty, sortingMode);
         return Ok(await _groupsService.GetPageAsync(properties, filter));
     }
 

--- a/Infrastructure/Filters/DefaultFilter.cs
+++ b/Infrastructure/Filters/DefaultFilter.cs
@@ -69,7 +69,7 @@ public class DefaultFilter<T> : IFilter<T>
     /// <returns>
     /// Filtered and sorted query that contains entities with a matched name.
     /// </returns>
-    public IQueryable<T> Apply(IQueryable<T> query)
+    public virtual IQueryable<T> Apply(IQueryable<T> query)
     {
         // Filter by name
         query = query.Where(x => x.Name.Contains(Name));

--- a/Infrastructure/Filters/GroupsFilter.cs
+++ b/Infrastructure/Filters/GroupsFilter.cs
@@ -1,0 +1,40 @@
+﻿using EUniversity.Core.Models.University;
+
+namespace EUniversity.Infrastructure.Filters;
+
+/// <summary>
+/// Filter for groups.
+/// </summary>
+public class GroupsFilter : DefaultFilter<Group>
+{
+    /// <summary>
+    /// Properties used for filtering.
+    /// </summary>
+    public GroupsFilterProperties Properties { get; }
+
+    public GroupsFilter(GroupsFilterProperties properties, 
+        string name, DefaultFilterSortingMode sortingMode = DefaultFilterSortingMode.Default) : 
+        base(name, sortingMode)
+    {
+        Properties = properties;
+    }
+
+    /// <inheritdoc />
+    public override IQueryable<Group> Apply(IQueryable<Group> query)
+    {
+        if (Properties.TeacherId != null)
+        {
+            query = query.Where(g => g.TeacherId == Properties.TeacherId);
+        }
+        if (Properties.SemesterId != null)
+        {
+            int? semesterId = Properties.SemesterId != 0 ? Properties.SemesterId : null;
+            query = query.Where(g => g.Course.SemesterId == semesterId);
+        }
+        if (Properties.CourseId != null)
+        {
+            query = query.Where(g => g.CourseId == Properties.CourseId);
+        }
+        return base.Apply(query);
+    }
+}

--- a/Infrastructure/Filters/GroupsFilterProperties.cs
+++ b/Infrastructure/Filters/GroupsFilterProperties.cs
@@ -1,0 +1,12 @@
+﻿namespace EUniversity.Infrastructure.Filters;
+
+/// <summary>
+/// Represents properties for filtering classes.
+/// </summary>
+/// <param name="TeacherId">Optional ID of the teacher to filter by.</param>
+/// <param name="CourseId">Optional ID of the course to filter by.</param>
+/// <param name="SemesterId">
+/// Optional ID of the semester to filter by.
+/// If 0, then groups that are not linked to any semesters will be returned.
+/// </param>
+public record GroupsFilterProperties(string? TeacherId = null, int? CourseId = null, int? SemesterId = null);

--- a/IntegrationTests/Controllers/University/GroupsControllerTests.cs
+++ b/IntegrationTests/Controllers/University/GroupsControllerTests.cs
@@ -25,7 +25,7 @@ public class GroupsControllerTests :
 
     public override int DefaultId => 1;
 
-    public override string GetPageFilter => "name=testfilter&sortingMode=name";
+    public override string GetPageFilter => "sortingMode=name&semesterId=0&courseId=12";
 
     protected override void AssertThatViewDtosAreEqual(GroupViewDto expected, GroupViewDto actual)
     {
@@ -87,8 +87,9 @@ public class GroupsControllerTests :
 
     protected override bool AssertThatFilterWasApplied(IFilter<Group> filter)
     {
-        return filter is DefaultFilter<Group> defaultFilter &&
-            defaultFilter.Name == "testfilter" &&
-            defaultFilter.SortingMode == DefaultFilterSortingMode.Name;
+        return filter is GroupsFilter groupsFilter &&
+            groupsFilter.Properties.SemesterId == 0 &&
+            groupsFilter.Properties.CourseId == 12 &&
+            groupsFilter.SortingMode == DefaultFilterSortingMode.Name;
     }
 }


### PR DESCRIPTION
This pull requests adds a filter for groups, which is, similarly to `SemestersFilter`, inherited from `DefaultFilter`. 

### New filter properties
* `TeacherId`.
* `CourseId`.
* `SemesterId` - if 0, returns groups which courses are not related to any semesters.

### Affected endpoints
* GET `api/groups`