### PR TITLE
Add Additional Students Methods

### DIFF
--- a/Core/Policy/Policies.cs
+++ b/Core/Policy/Policies.cs
@@ -5,6 +5,7 @@ public static class Policies
     public const string Default = "Default";
     public const string IsStudent = "IsStudent";
     public const string IsTeacher = "IsTeacher";
+    public const string IsTeacherOrAdministrator = "IsTeacherOrAdmin";
     public const string HasAdministratorPermission = "HasAdministratorPermission";
     public const string CanViewStudentEnrollments = "CanViewStudentEnrollments";
 }

--- a/Core/Policy/Policies.cs
+++ b/Core/Policy/Policies.cs
@@ -6,4 +6,5 @@ public static class Policies
     public const string IsStudent = "IsStudent";
     public const string IsTeacher = "IsTeacher";
     public const string HasAdministratorPermission = "HasAdministratorPermission";
+    public const string CanViewStudentEnrollments = "CanViewStudentEnrollments";
 }

--- a/Core/Services/Users/IUsersService.cs
+++ b/Core/Services/Users/IUsersService.cs
@@ -1,6 +1,8 @@
-﻿using EUniversity.Core.Dtos.Users;
+﻿using EUniversity.Core.Dtos.University;
+using EUniversity.Core.Dtos.Users;
 using EUniversity.Core.Filters;
 using EUniversity.Core.Models;
+using EUniversity.Core.Models.University;
 using EUniversity.Core.Pagination;
 
 namespace EUniversity.Core.Services.Users;
@@ -31,4 +33,24 @@ public interface IUsersService
     /// Page with all users.
     /// </returns>
     Task<Page<UserViewDto>> GetAllUsersAsync(PaginationProperties? properties = null, IFilter<ApplicationUser>? filter = null);
+
+    /// <summary>
+    /// Gets a page with groups of the student.
+    /// </summary>
+    /// <param name="studentId">An ID of the student.</param>
+    /// <param name="filter">Optional filter for groups.</param>
+    /// <returns>
+    /// A page with groups of the student with ID <paramref name="studentId"/>.
+    /// </returns>
+    Task<Page<GroupPreviewDto>> GetGroupsOfStudentAsync(string studentId, PaginationProperties properties, IFilter<Group>? filter = null);
+
+    /// <summary>
+    /// Gets a page with semesters of the student.
+    /// </summary>
+    /// <param name="studentId">An ID of the student.</param>
+    /// <param name="filter">Optional filter for semesters.</param>
+    /// <returns>
+    /// A page with semesters of the student with ID <paramref name="studentId"/>.
+    /// </returns>
+    Task<Page<SemesterPreviewDto>> GetSemestersOfStudentAsync(string studentId, PaginationProperties properties, IFilter<Semester>? filter = null);
 }

--- a/EUniversity.Tests/Auth/ViewStudentEnrollmentsAuthorizationHandlerTests.cs
+++ b/EUniversity.Tests/Auth/ViewStudentEnrollmentsAuthorizationHandlerTests.cs
@@ -1,0 +1,98 @@
+﻿using EUniversity.Auth;
+using EUniversity.Controllers;
+using EUniversity.Core.Policy;
+using IdentityModel;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Routing;
+using System.Security.Claims;
+
+namespace EUniversity.Tests.Auth;
+
+public class ViewStudentEnrollmentsAuthorizationHandlerTests
+{
+    private readonly string TestUserId = Guid.NewGuid().ToString();
+    private readonly string TestRouteStudentId = Guid.NewGuid().ToString();
+
+    private ClaimsPrincipal GetUser(string id, params string[] roles)
+    {
+        List<Claim> claims =new()
+        {
+            new(JwtClaimTypes.Subject, id)
+        };
+        foreach (string role in roles)
+        {
+            claims.Add(new(JwtClaimTypes.Role, role));
+        }
+        ClaimsIdentity identity = new(claims, "Test");
+        return new ClaimsPrincipal(identity);
+    }
+
+    private AuthorizationHandlerContext GetHandlerContext(ClaimsPrincipal user)
+    {
+        RouteValueDictionary routeValues = new()
+        {
+            { UsersController.StudentIdRouteKey, TestRouteStudentId }
+        };
+        HttpContext httpContext = Substitute.For<HttpContext>();
+        var routeValuesFeature = Substitute.For<IRouteValuesFeature>();
+        routeValuesFeature.RouteValues.Returns(routeValues);
+
+        httpContext.Features.Get<IRouteValuesFeature>().Returns(routeValuesFeature);
+
+        IAuthorizationRequirement[] requirements =
+        {
+            new ViewStudentEnrollmentsAuthorizationRequirement()
+        };
+
+        return new(requirements, user, httpContext);
+    }
+
+    [Test]
+    [TestCase(Roles.Administrator)]
+    [TestCase(Roles.Teacher)]
+    public async Task AdministratorOrTeacher_Succeeds(string role)
+    {
+        // Arrange
+        ClaimsPrincipal user = GetUser(TestUserId, role);
+        AuthorizationHandlerContext context = GetHandlerContext(user); 
+        ViewStudentEnrollmentsAuthorizationHandler handler = new();
+
+        // Act
+        await handler.HandleAsync(context);
+
+        // Assert
+        Assert.That(context.HasSucceeded);
+    }
+
+    [Test]
+    public async Task UserAccessesOwnEnrollments_Succeeds()
+    {
+        // Arrange
+        ClaimsPrincipal user = GetUser(TestRouteStudentId);
+        AuthorizationHandlerContext context = GetHandlerContext(user); 
+        ViewStudentEnrollmentsAuthorizationHandler handler = new();
+
+        // Act
+        await handler.HandleAsync(context);
+
+        // Assert
+        Assert.That(context.HasSucceeded);
+    }
+
+    [Test]
+    public async Task UserAccessesEnrollmentsOfAnotherUser_Fails()
+    {
+        // Arrange
+        ClaimsPrincipal user = GetUser(TestUserId);
+        AuthorizationHandlerContext context = GetHandlerContext(user); 
+        ViewStudentEnrollmentsAuthorizationHandler handler = new();
+
+        // Act
+        await handler.HandleAsync(context);
+
+        // Assert
+        Assert.That(context.HasFailed);
+    }
+}

--- a/EUniversity/Auth/ViewStudentEnrollmentsAuthorizationHandler.cs
+++ b/EUniversity/Auth/ViewStudentEnrollmentsAuthorizationHandler.cs
@@ -1,0 +1,50 @@
+﻿using Duende.IdentityServer.Extensions;
+using EUniversity.Controllers;
+using EUniversity.Core.Policy;
+using IdentityModel;
+using Microsoft.AspNetCore.Authorization;
+
+namespace EUniversity.Auth;
+
+/// <summary>
+/// Authorization handler that determines whether user can view students enrollments.
+/// Allows teachers and administrators to view all enrollments and other users to view
+/// only their own enrollments.
+/// </summary>
+public class ViewStudentEnrollmentsAuthorizationHandler :
+    AuthorizationHandler<ViewStudentEnrollmentsAuthorizationRequirement>
+{
+    protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, ViewStudentEnrollmentsAuthorizationRequirement requirement)
+    {
+        if (!context.User.IsAuthenticated())
+        {
+            context.Fail();
+            return Task.CompletedTask;
+        }
+        // If user is either a teacher or an administrator,
+        // he/she has an access to all enrollments
+        if (context.User.HasClaim(JwtClaimTypes.Role, Roles.Teacher) ||
+            context.User.HasClaim(JwtClaimTypes.Role, Roles.Administrator))
+        {
+            context.Succeed(requirement);
+            return Task.CompletedTask;
+        }
+
+        // Get an ID from route values
+        if (context.Resource is not HttpContext httpContext)
+        {
+            throw new InvalidOperationException("Cannot access HTTP context");
+        }
+        object? routeId = httpContext.GetRouteValue(UsersController.StudentIdRouteKey) ??
+            throw new InvalidOperationException($"Cannot get route value of '{UsersController.StudentIdRouteKey}'");
+        // Each user can view his/her enrollments
+        if (context.User.GetSubjectId() == routeId.ToString())
+        {
+            context.Succeed(requirement);
+            return Task.CompletedTask;
+        }
+
+        context.Fail();
+        return Task.CompletedTask;
+    }
+}

--- a/EUniversity/Auth/ViewStudentEnrollmentsAuthorizationRequirement.cs
+++ b/EUniversity/Auth/ViewStudentEnrollmentsAuthorizationRequirement.cs
@@ -1,0 +1,7 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace EUniversity.Auth;
+
+public class ViewStudentEnrollmentsAuthorizationRequirement : IAuthorizationRequirement
+{
+}

--- a/EUniversity/Controllers/UsersController.cs
+++ b/EUniversity/Controllers/UsersController.cs
@@ -19,6 +19,8 @@ public class UsersController : ControllerBase
     private readonly IAuthService _authService;
     private readonly IUsersService _usersService;
 
+    public const string StudentIdRouteKey = "studentId";
+
     public UsersController(IAuthService authService, IUsersService usersService)
     {
         _authService = authService;

--- a/EUniversity/Controllers/UsersController.cs
+++ b/EUniversity/Controllers/UsersController.cs
@@ -13,7 +13,7 @@ namespace EUniversity.Controllers;
 [ApiController]
 [Route("api/users")]
 [FluentValidationAutoValidation]
-[Authorize(Policies.HasAdministratorPermission)]
+[Authorize]
 public class UsersController : ControllerBase
 {
     private readonly IAuthService _authService;
@@ -50,6 +50,7 @@ public class UsersController : ControllerBase
     [ProducesResponseType(typeof(Page<UserViewDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [Authorize(Policies.HasAdministratorPermission)]
     public async Task<IActionResult> GetAllUsersAsync(
         [FromQuery] PaginationProperties paginationProperties,
         [FromQuery] UsersFilterProperties usersFilter)
@@ -75,12 +76,13 @@ public class UsersController : ControllerBase
     /// </remarks>
     /// <response code="200">Returns a page with students</response>
     /// <response code="401">Unauthorized user call</response>
-    /// <response code="403">User lacks 'Administrator' role</response>
+    /// <response code="403">User lacks 'Administrator' or 'Teacher' role</response>
     [HttpGet]
     [Route("students")]
     [ProducesResponseType(typeof(Page<UserViewDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [Authorize(Policies.IsTeacherOrAdministrator)]
     public async Task<IActionResult> GetAllStudentsAsync(
         [FromQuery] PaginationProperties paginationProperties,
         [FromQuery] UsersFilterProperties usersFilter)
@@ -106,7 +108,6 @@ public class UsersController : ControllerBase
     /// </remarks>
     /// <response code="200">Returns a page with teachers</response>
     /// <response code="401">Unauthorized user call</response>
-    /// <response code="403">User lacks 'Administrator' role</response>
     [HttpGet]
     [Route("teachers")]
     [ProducesResponseType(typeof(Page<UserViewDto>), StatusCodes.Status200OK)]
@@ -158,6 +159,7 @@ public class UsersController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [Authorize(Policies.HasAdministratorPermission)]
     public async Task<IActionResult> RegisterStudentsAsync([FromBody] RegisterUsersDto students)
     {
         return await RegisterAsync(students, Roles.Student, "api/users/students");
@@ -181,6 +183,7 @@ public class UsersController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [Authorize(Policies.HasAdministratorPermission)]
     public async Task<IActionResult> RegisterTeachersAsync([FromBody] RegisterUsersDto teachers)
     {
         return await RegisterAsync(teachers, Roles.Teacher, "api/users/teachers");

--- a/EUniversity/Controllers/UsersController.cs
+++ b/EUniversity/Controllers/UsersController.cs
@@ -1,4 +1,5 @@
-﻿using EUniversity.Core.Dtos.Users;
+﻿using EUniversity.Core.Dtos.University;
+using EUniversity.Core.Dtos.Users;
 using EUniversity.Core.Pagination;
 using EUniversity.Core.Policy;
 using EUniversity.Core.Services.Auth;
@@ -187,6 +188,118 @@ public class UsersController : ControllerBase
     public async Task<IActionResult> RegisterTeachersAsync([FromBody] RegisterUsersDto teachers)
     {
         return await RegisterAsync(teachers, Roles.Teacher, "api/users/teachers");
+    }
+    #endregion
+
+    #region Enrollments
+    /// <summary>
+    /// Gets a page with groups of the student.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If a user has the 'Administrator' or 'Teacher' role then he/she can use this method
+    /// for every user, otherwise a user can view only his/her own groups.
+    /// </para>
+    /// <para>
+    /// The 'studentId' route value is not checked in this method, if student with
+    /// this ID does not exist, then empty page will be returned.
+    /// </para>
+    /// <para>
+    /// If there is no items in the requested page, then empty page will be returned.
+    /// </para>
+    /// <para>
+    /// If the query param 'semesterId' is 0, then groups that are not linked to any semesters will be returned.</para>
+    /// </remarks>
+    /// <param name="studentId">ID of the student whose groups will be returned.</param>
+    /// <param name="properties">Pagination properties.</param>
+    /// <param name="filterProperties">Filter properties.</param>
+    /// <param name="name">An optional name to filter groups by.</param>
+    /// <param name="sortingMode">
+    /// An optional sorting mode.
+    /// <para>
+    /// Possible values:
+    /// </para>
+    /// <ul>
+    /// <li>default(or 0) - no sorting will be applied;</li>
+    /// <li>name(or 1) - groups will be sorted by their name(from a to z), this mode is applied by default;</li>
+    /// <li>nameDescending(or 2) - groups will be sorted by their name in descending order(from z to a);</li>
+    /// <li>newest(or 3) - groups will be sorted by their creation date in descending order;</li>
+    /// <li>oldest(or 4) - groups will be sorted by their creation date in ascending order.</li>
+    /// </ul>
+    /// </param>
+    /// <response code="200">Returns requested page with groups.</response>
+    /// <response code="400">Bad request.</response>
+    /// <response code="401">Unauthorized user call.</response>
+    /// <response code="403">User don't have a permission to view specified student's enrollments.</response>
+    [HttpGet("students/{studentId}/groups")]
+    [Authorize(Policies.CanViewStudentEnrollments)]
+    [ProducesResponseType(typeof(Page<GroupPreviewDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetStudentGroupsAsync(
+        [FromRoute] string studentId,
+        [FromQuery] PaginationProperties properties,
+        [FromQuery] GroupsFilterProperties filterProperties,
+        [FromQuery] string? name,
+        [FromQuery] DefaultFilterSortingMode sortingMode = DefaultFilterSortingMode.Name)
+    {
+        GroupsFilter filter = new(filterProperties, name ?? string.Empty, sortingMode);
+        return Ok(await _usersService.GetGroupsOfStudentAsync(studentId, properties, filter));
+    }
+
+    /// <summary>
+    /// Gets a page with semesters of the student.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If a user has the 'Administrator' or 'Teacher' role then he/she can use this method
+    /// for every user, otherwise a user can view only his/her own semesters.
+    /// </para>
+    /// <para>
+    /// The 'studentId' route value is not checked in this method, if student with
+    /// this ID does not exist, then empty page will be returned.
+    /// </para>
+    /// <para>
+    /// If there is no items in the requested page, then empty page will be returned.
+    /// </para>
+    /// <para>
+    /// If the query param 'semesterId' is 0, then semesters that are not linked to any semesters will be returned.</para>
+    /// </remarks>
+    /// <param name="studentId">ID of the student whose semesters will be returned.</param>
+    /// <param name="properties">Pagination properties.</param>
+    /// <param name="filterProperties">Filter properties.</param>
+    /// <param name="name">An optional name to filter semesters by.</param>
+    /// <param name="sortingMode">
+    /// An optional sorting mode.
+    /// <para>
+    /// Possible values:
+    /// </para>
+    /// <ul>
+    /// <li>default(or 0) - no sorting will be applied;</li>
+    /// <li>name(or 1) - semesters will be sorted by their name(from a to z), this mode is applied by default;</li>
+    /// <li>nameDescending(or 2) - semesters will be sorted by their name in descending order(from z to a);</li>
+    /// <li>newest(or 3) - semesters will be sorted by their creation date in descending order;</li>
+    /// <li>oldest(or 4) - semesters will be sorted by their creation date in ascending order.</li>
+    /// </ul>
+    /// </param>
+    /// <response code="200">Returns requested page with semesters.</response>
+    /// <response code="400">Bad request.</response>
+    /// <response code="401">Unauthorized user call.</response>
+    /// <response code="403">User don't have a permission to view specified student's enrollments.</response>
+    [HttpGet("students/{studentId}/semesters")]
+    [Authorize(Policies.CanViewStudentEnrollments)]
+    [ProducesResponseType(typeof(Page<SemesterPreviewDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetStudentSemestersAsync(
+        [FromRoute] string studentId,
+        [FromQuery] PaginationProperties properties,
+        [FromQuery] SemestersFilterProperties filterProperties,
+        [FromQuery] string? name,
+        [FromQuery] DefaultFilterSortingMode sortingMode = DefaultFilterSortingMode.Name)
+    {
+        SemestersFilter filter = new(filterProperties, name ?? string.Empty, sortingMode);
+        return Ok(await _usersService.GetSemestersOfStudentAsync(studentId, properties, filter));
     }
     #endregion
 }

--- a/EUniversity/Extensions/ServiceCollectionExtensions.cs
+++ b/EUniversity/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using EUniversity.Core.Models;
+﻿using EUniversity.Auth;
+using EUniversity.Core.Models;
 using EUniversity.Core.Policy;
 using EUniversity.Core.Services;
 using EUniversity.Core.Services.Auth;
@@ -16,6 +17,7 @@ using EUniversity.Infrastructure.Services.Users;
 using FluentValidation;
 using IdentityModel;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using SharpGrip.FluentValidation.AutoValidation.Mvc.Enums;
 using SharpGrip.FluentValidation.AutoValidation.Mvc.Extensions;
@@ -96,6 +98,8 @@ public static class ServiceCollectionExtensions
 
     public static IServiceCollection AddCustomizedAuthorization(this IServiceCollection services, params string[] authenticationSchemes)
     {
+        services.AddTransient<IAuthorizationHandler, ViewStudentEnrollmentsAuthorizationHandler>();
+
         return services.AddAuthorization(options =>
         {
             options.AddPolicy(Policies.Default, policy =>
@@ -103,6 +107,7 @@ public static class ServiceCollectionExtensions
                 policy.AddAuthenticationSchemes(authenticationSchemes);
                 policy.RequireAuthenticatedUser();
             });
+            // Simple role-based policies
             options.AddPolicy(Policies.IsStudent, policy =>
             {
                 policy.AddAuthenticationSchemes(authenticationSchemes);
@@ -120,6 +125,13 @@ public static class ServiceCollectionExtensions
                 policy.AddAuthenticationSchemes(authenticationSchemes);
                 policy.RequireAuthenticatedUser();
                 policy.RequireClaim(JwtClaimTypes.Role, Roles.Administrator);
+            });
+            // Policies that use authorization requirements
+            options.AddPolicy(Policies.CanViewStudentEnrollments, policy =>
+            {
+                policy.AddAuthenticationSchemes(authenticationSchemes);
+                policy.RequireAuthenticatedUser();
+                policy.AddRequirements(new ViewStudentEnrollmentsAuthorizationRequirement());
             });
             options.DefaultPolicy = options.GetPolicy(Policies.Default)!;
         });

--- a/EUniversity/Extensions/ServiceCollectionExtensions.cs
+++ b/EUniversity/Extensions/ServiceCollectionExtensions.cs
@@ -120,6 +120,12 @@ public static class ServiceCollectionExtensions
                 policy.RequireAuthenticatedUser();
                 policy.RequireClaim(JwtClaimTypes.Role, Roles.Teacher);
             });
+            options.AddPolicy(Policies.IsTeacherOrAdministrator, policy =>
+            {
+                policy.AddAuthenticationSchemes(authenticationSchemes);
+                policy.RequireAuthenticatedUser();
+                policy.RequireClaim(JwtClaimTypes.Role, Roles.Teacher, Roles.Administrator);
+            });
             options.AddPolicy(Policies.HasAdministratorPermission, policy =>
             {
                 policy.AddAuthenticationSchemes(authenticationSchemes);

--- a/IntegrationTests/Controllers/UsersControllerTests.cs
+++ b/IntegrationTests/Controllers/UsersControllerTests.cs
@@ -294,7 +294,7 @@ public class UsersControllerTests : ControllersTest
 
         // Assert
         result.EnsureSuccessStatusCode();
-        var groups = await result.Content.ReadFromJsonAsync<IEnumerable<GroupPreviewDto>>();
+        var groups = await result.Content.ReadFromJsonAsync<Page<GroupPreviewDto>>();
         Assert.That(groups, Is.Not.Null);
         await WebApplicationFactory.UsersServiceMock
             .Received()
@@ -334,7 +334,7 @@ public class UsersControllerTests : ControllersTest
 
         // Assert
         result.EnsureSuccessStatusCode();
-        var semesters = await result.Content.ReadFromJsonAsync<IEnumerable<SemesterPreviewDto>>();
+        var semesters = await result.Content.ReadFromJsonAsync<Page<SemesterPreviewDto>>();
         Assert.That(semesters, Is.Not.Null);
         await WebApplicationFactory.UsersServiceMock
             .Received()

--- a/IntegrationTests/Controllers/UsersControllerTests.cs
+++ b/IntegrationTests/Controllers/UsersControllerTests.cs
@@ -167,14 +167,26 @@ public class UsersControllerTests : ControllersTest
     }
 
     [Test]
-    [TestCaseSource(nameof(GetMethods))]
-    public async Task GetMethods_NoAdministratorRole_Return403Forbidden(string method)
+    public async Task GetUsers_NoAdministratorRole_Return403Forbidden()
     {
         // Arrange
         using var client = CreateStudentClient();
 
         // Act
-        var result = await client.GetAsync(method);
+        var result = await client.GetAsync("api/users");
+
+        // Assert
+        Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
+    }
+
+    [Test]
+    public async Task GetStudents_NoAdministratorOrTeacherRole_Return403Forbidden()
+    {
+        // Arrange
+        using var client = CreateStudentClient();
+
+        // Act
+        var result = await client.GetAsync("api/users/students");
 
         // Assert
         Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));

--- a/IntegrationTests/Services/UsersServiceTests.cs
+++ b/IntegrationTests/Services/UsersServiceTests.cs
@@ -1,9 +1,12 @@
-﻿using EUniversity.Core.Filters;
+﻿using EUniversity.Core.Dtos.University;
+using EUniversity.Core.Filters;
 using EUniversity.Core.Models;
+using EUniversity.Core.Models.University;
 using EUniversity.Core.Pagination;
 using EUniversity.Core.Policy;
 using EUniversity.Core.Services.Users;
 using EUniversity.Infrastructure.Filters;
+using Mapster;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 
@@ -151,5 +154,125 @@ public class UsersServiceTests : ServicesTest
             Assert.That(result.TotalItemsCount, Is.EqualTo(expectedIds.Length));
             Assert.That(result.Items.Select(u => u.Id), Is.EquivalentTo(expectedIds));
         });
+    }
+
+    [Test]
+    public async Task GetGroupsOfStudent_ReturnsGroupsOfStudent()
+    {
+        // Arrange
+        var student = await RegisterTestUserAsync(Roles.Student);
+        Course course = new()
+        {
+            Name = "Some course"
+        };
+        DbContext.Add(course);
+        await DbContext.SaveChangesAsync();
+        Group group1 = new()
+        {
+            Name = "G1",
+            CourseId = course.Id
+        };
+        Group group2 = new()
+        {
+            Name = "G2",
+            CourseId = course.Id
+        };
+        DbContext.Add(group1);
+        DbContext.Add(group2);
+        await DbContext.SaveChangesAsync();
+        // Add student to a group
+        StudentGroup studentGroup = new()
+        {
+            StudentId = student.Id,
+            GroupId = group1.Id
+        };
+        DbContext.Add(studentGroup);
+        await DbContext.SaveChangesAsync();
+        GroupPreviewDto[] expectedResult =
+        {
+            group1.Adapt<GroupPreviewDto>()
+        };
+
+        // Act
+        var result = await _usersService
+            .GetGroupsOfStudentAsync(student.Id, new PaginationProperties());
+
+        // Assert
+        Assert.That(result.Items, Is.EquivalentTo(expectedResult));
+    }
+
+    [Test]
+    public async Task GetGroupsOfStudent_AppliesFilter()
+    {
+        // Arrange
+        var student = await RegisterTestUserAsync();
+        IFilter<Group> filterMock = Substitute.For<IFilter<Group>>();
+        filterMock
+            .Apply(Arg.Any<IQueryable<Group>>())
+            .Returns(x => x.ArgAt<IQueryable<Group>>(0));
+
+        // Act
+        await _usersService.GetGroupsOfStudentAsync(student.Id, new PaginationProperties(), filterMock);
+
+        // Assert
+        filterMock
+            .Received()
+            .Apply(Arg.Any<IQueryable<Group>>());
+    }
+
+    [Test]
+    public async Task GetSemestersOfStudent_ReturnsSemestersOfStudent()
+    {
+        // Arrange
+        var student = await RegisterTestUserAsync(Roles.Student);
+        Semester semester1 = new()
+        {
+            Name = "S1"
+        };
+        Semester semester2 = new()
+        {
+            Name = "S2"
+        };
+        DbContext.Add(semester1);
+        DbContext.Add(semester2);
+        await DbContext.SaveChangesAsync();
+        // Add student to a semester
+        StudentSemester studentSemester = new()
+        {
+            StudentId = student.Id,
+            SemesterId = semester1.Id
+        };
+        DbContext.Add(studentSemester);
+        await DbContext.SaveChangesAsync();
+        SemesterPreviewDto[] expectedResult =
+        {
+            semester1.Adapt<SemesterPreviewDto>()
+        };
+
+        // Act
+        var result = await _usersService
+            .GetSemestersOfStudentAsync(student.Id, new PaginationProperties());
+
+        // Assert
+        Assert.That(result.Items, Is.EquivalentTo(expectedResult));
+    }
+
+    [Test]
+    public async Task GetSemestersOfStudent_AppliesFilter()
+    {
+        // Arrange
+        var student = await RegisterTestUserAsync();
+        IFilter<Semester> filterMock = Substitute.For<IFilter<Semester>>();
+        filterMock
+            .Apply(Arg.Any<IQueryable<Semester>>())
+            .Returns(x => x.ArgAt<IQueryable<Semester>>(0));
+
+        // Act
+        await _usersService.GetSemestersOfStudentAsync(student.Id, new PaginationProperties(), filterMock);
+
+        // Assert
+        filterMock
+            .Received()
+            .Apply(Arg.Any<IQueryable<Semester>>());
     }
 }


### PR DESCRIPTION
This pull request adds additonal methods in `UsersController` and applies policy changes from pull request #56.

### Added endpoints
* GET `api/users/students/[studentId]/groups`
* GET `api/users/students/[studentId]/semesters`

These methods allows administrators and teachers unrestricted access. For other users, access is granted only if their user ID matches the requested ID.  They do not validate `studentId`(more information is available in swagger documentation).

### Changes made
* Added an authorization handler `ViewStudentEnrollmentsAuthorizationHandler`.
#### From pull request #56:
* `GET api/users/teachers` method is now allowed for all registered users.
* `GET api/users/students` is now allowed for teachers and administrators.